### PR TITLE
Improve coverage cloudwatch logger

### DIFF
--- a/cloudwatch_logs_common/CMakeLists.txt
+++ b/cloudwatch_logs_common/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 
 set(ALL_SRC_FILES src/log_manager.cpp src/log_manager_factory.cpp src/log_publisher.cpp src/utils/cloudwatch_facade.cpp)
 
-add_library(${PROJECT_NAME} ${ALL_SRC_FILES})
+add_library(${PROJECT_NAME} SHARED ${ALL_SRC_FILES})
 target_link_libraries(${PROJECT_NAME} ${OUTPUT})
 target_include_directories(${PROJECT_NAME} PRIVATE ${AWSSDK_INCLUDE_DIRS} include ${aws_common_INCLUDE_DIRS})
 target_include_directories(${PROJECT_NAME} PUBLIC

--- a/cloudwatch_logs_common/include/cloudwatch_logs_common/log_manager_factory.h
+++ b/cloudwatch_logs_common/include/cloudwatch_logs_common/log_manager_factory.h
@@ -38,7 +38,7 @@ public:
    *
    *  @return An instance of LogManager
    */
-  std::shared_ptr<LogManager> CreateLogManager(
+  virtual std::shared_ptr<LogManager> CreateLogManager(
     const std::string & log_group, const std::string & log_stream,
     const Aws::Client::ClientConfiguration & client_config, const Aws::SDKOptions & sdk_options);
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This changes enable adding unit tests to cloudwatchlogs-ros1 easily

- Making the cloudwatch_logs_common a shared library allows to use it to build other libs. Otherwise we get  an error `/usr/bin/ld: /opt/workspace/install/cloudwatch_logs_common/lib/libcloudwatch_logs_common.a(log_manager_factory.cpp.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC` during build. Using a shared library for the common package was also done for other common packages like [kinesisvideo-common](https://github.com/aws-robotics/kinesisvideo-common/blob/master/kinesis_manager/CMakeLists.txt#L21)

- Making the factory method of `LogManagerFactory` virtual allows to replace it easily with a mock, and it's also consistent with `LogManager` and `LogPublisher` that already use virtual methods. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
