### PR TITLE
adds unit tests for cloudwatch facade

### DIFF
--- a/cloudwatch_logs_common/CMakeLists.txt
+++ b/cloudwatch_logs_common/CMakeLists.txt
@@ -63,17 +63,23 @@ find_package(GTest QUIET)
 if(NOT GTEST_FOUND)
   message(WARNING "Could not find GTest. Not building unit tests.")
 else()
+  include_directories(/usr/include/gmock /usr/src/gmock)
+  add_library(libgmock /usr/src/gmock/src/gmock-all.cc)
   add_executable(test_cloudwatch_logs_common
     test/main_test.cpp
     test/shared_object_test.cpp
     test/log_manager_test.cpp
-    test/log_publisher_test.cpp)
+    test/log_publisher_test.cpp
+    test/cloudwatch_facade_test.cpp)
   target_include_directories(test_cloudwatch_logs_common
         PRIVATE include
-        PRIVATE ${aws_common_INCLUDE_DIRS})
+        PRIVATE ${aws_common_INCLUDE_DIRS}
+        PUBLIC ${PROJECT_SOURCE_DIR}/test/include
+        )
   target_link_libraries(test_cloudwatch_logs_common
         ${GTEST_LIBRARIES}
         pthread
+        libgmock
         ${PROJECT_NAME})
   add_test(NAME test_cloudwatch_logs_common COMMAND test_cloudwatch_logs_common --gtest_output=xml:test_results/)
 endif()

--- a/cloudwatch_logs_common/include/cloudwatch_logs_common/utils/cloudwatch_facade.h
+++ b/cloudwatch_logs_common/include/cloudwatch_logs_common/utils/cloudwatch_facade.h
@@ -43,6 +43,14 @@ public:
    *  @param client_config The configuration for the cloudwatch client
    */
   CloudWatchFacade(const Aws::Client::ClientConfiguration & client_config);
+
+  /**
+   * @brief Creates a new CloudWatchFacade with an existing client
+   *
+   * @param cw_client The client for interacting with cloudwatch
+   */
+  CloudWatchFacade(const std::unique_ptr<Aws::CloudWatchLogs::CloudWatchLogsClient> cw_client);
+
   virtual ~CloudWatchFacade() = default;
 
   /**
@@ -115,12 +123,13 @@ public:
 
 protected:
   CloudWatchFacade() = default;
+  
+  std::unique_ptr<Aws::CloudWatchLogs::CloudWatchLogsClient> cw_client_;
 
 private:
   Aws::CloudWatchLogs::ROSCloudWatchLogsErrors SendLogsRequest(
     const Aws::CloudWatchLogs::Model::PutLogEventsRequest & request, Aws::String & next_token);
 
-  Aws::CloudWatchLogs::CloudWatchLogsClient cw_client_;
 };
 
 }  // namespace Utils

--- a/cloudwatch_logs_common/src/utils/cloudwatch_facade.cpp
+++ b/cloudwatch_logs_common/src/utils/cloudwatch_facade.cpp
@@ -34,7 +34,12 @@ using namespace Aws::CloudWatchLogs::Utils;
 constexpr uint16_t kMaxLogsPerRequest = 100;
 
 CloudWatchFacade::CloudWatchFacade(const Aws::Client::ClientConfiguration & client_config)
-: cw_client_(client_config)
+{
+  this->cw_client_ = std::make_unique<Aws::CloudWatchLogs::CloudWatchLogsClient>(client_config);
+}
+
+CloudWatchFacade::CloudWatchFacade(std::unique_ptr<Aws::CloudWatchLogs::CloudWatchLogsClient> cw_client)
+: cw_client_(std::move(cw_client))
 {
 }
 
@@ -42,7 +47,7 @@ Aws::CloudWatchLogs::ROSCloudWatchLogsErrors CloudWatchFacade::SendLogsRequest(
   const Aws::CloudWatchLogs::Model::PutLogEventsRequest & request, Aws::String & next_token)
 {
   Aws::CloudWatchLogs::ROSCloudWatchLogsErrors status = CW_LOGS_SUCCEEDED;
-  auto response = this->cw_client_.PutLogEvents(request);
+  auto response = this->cw_client_->PutLogEvents(request);
   if (!response.IsSuccess()) {
     status = CW_LOGS_FAILED;
     AWS_LOGSTREAM_ERROR(__func__, "Send log request failed due to: "
@@ -132,7 +137,7 @@ Aws::CloudWatchLogs::ROSCloudWatchLogsErrors CloudWatchFacade::CreateLogGroup(
   Aws::CloudWatchLogs::Model::CreateLogGroupRequest log_group_request;
   log_group_request.SetLogGroupName(log_group.c_str());
 
-  const auto & response = this->cw_client_.CreateLogGroup(log_group_request);
+  const auto & response = this->cw_client_->CreateLogGroup(log_group_request);
   if (!response.IsSuccess()) {
     AWS_LOGSTREAM_ERROR(
       __func__, "Failed to create Log Group :"
@@ -163,7 +168,7 @@ Aws::CloudWatchLogs::ROSCloudWatchLogsErrors CloudWatchFacade::CheckLogGroupExis
       describe_log_group_request.SetNextToken(next_token);
     }
 
-    const auto & response = this->cw_client_.DescribeLogGroups(describe_log_group_request);
+    const auto & response = this->cw_client_->DescribeLogGroups(describe_log_group_request);
     if (!response.IsSuccess()) {
       status = CW_LOGS_FAILED;
       AWS_LOGSTREAM_WARN(__func__, "Request to check if log group named "
@@ -202,7 +207,7 @@ Aws::CloudWatchLogs::ROSCloudWatchLogsErrors CloudWatchFacade::CreateLogStream(
   log_stream_request.SetLogGroupName(log_group.c_str());
   log_stream_request.SetLogStreamName(log_stream.c_str());
 
-  const auto & response = this->cw_client_.CreateLogStream(log_stream_request);
+  const auto & response = this->cw_client_->CreateLogStream(log_stream_request);
   if (!response.IsSuccess()) {
     AWS_LOGSTREAM_ERROR(__func__, "Failed to create Log Stream :"
                                     << log_stream << " in Log Group :" << log_group << " due to: "
@@ -235,7 +240,7 @@ Aws::CloudWatchLogs::ROSCloudWatchLogsErrors CloudWatchFacade::CheckLogStreamExi
       describe_log_stream_request.SetNextToken(next_token);
     }
 
-    const auto & response = this->cw_client_.DescribeLogStreams(describe_log_stream_request);
+    const auto & response = this->cw_client_->DescribeLogStreams(describe_log_stream_request);
     if (!response.IsSuccess()) {
       status = CW_LOGS_FAILED;
       AWS_LOGSTREAM_WARN(

--- a/cloudwatch_logs_common/test/cloudwatch_facade_test.cpp
+++ b/cloudwatch_logs_common/test/cloudwatch_facade_test.cpp
@@ -1,0 +1,297 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/core/Aws.h>
+#include <aws/core/client/AWSClient.h>
+#include <aws/core/NoResult.h>
+#include <cloudwatch_logs_common/cloudwatch_logs_client_mock.h>
+#include <cloudwatch_logs_common/ros_cloudwatch_logs_errors.h>
+#include <cloudwatch_logs_common/utils/cloudwatch_facade.h>
+#include <gtest/gtest.h>
+
+
+using namespace Aws::CloudWatchLogs::Utils;
+
+
+constexpr char LOG_GROUP_NAME1[] = "TestGroup1";
+constexpr char LOG_GROUP_NAME2[] = "TestGroup2";
+constexpr char LOG_STREAM_NAME1[] = "TestStream1";
+constexpr char LOG_STREAM_NAME2[] = "TestStream2";
+
+
+class TestCloudWatchFacade : public ::testing::Test
+{
+protected:
+  std::list<Aws::CloudWatchLogs::Model::InputLogEvent> logs_list_;
+  Aws::SDKOptions options_;
+  std::shared_ptr<CloudWatchFacade> facade_;
+  std::unique_ptr<CloudWatchLogsClientMock> mock_client;
+  CloudWatchLogsClientMock* mock_client_p;
+
+  void SetUp() override
+  {
+    // the tests require non-empty logs_list_
+    logs_list_.emplace_back();
+    logs_list_.emplace_back();
+
+    Aws::InitAPI(options_);
+    mock_client = std::make_unique<CloudWatchLogsClientMock>();
+    mock_client_p = mock_client.get();
+    facade_ = std::make_shared<CloudWatchFacade>(std::move(mock_client));
+  }
+
+  void TearDown() override
+  {
+    Aws::ShutdownAPI(options_);
+  }
+};
+
+
+/*
+ * SendLogsToCloudWatch Tests
+ */
+
+TEST_F(TestCloudWatchFacade, TestCWLogsFacade_SendLogsToCloudWatch_NullLogs)
+{
+    Aws::String nextToken;
+    EXPECT_EQ(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_NULL_PARAMETER,
+        facade_->SendLogsToCloudWatch(nextToken, "", "", nullptr));
+}
+
+TEST_F(TestCloudWatchFacade, TestCWLogsFacade_SendLogsToCloudWatch_EmptyLogs)
+{
+    std::list<Aws::CloudWatchLogs::Model::InputLogEvent> empty_logs_list;
+    Aws::String nextToken;
+    EXPECT_EQ(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_EMPTY_PARAMETER,
+        facade_->SendLogsToCloudWatch(nextToken, "", "", &empty_logs_list));
+}
+
+TEST_F(TestCloudWatchFacade, TestCWLogsFacade_SendLogsToCloudWatch_FailedResponse)
+{
+    Aws::CloudWatchLogs::Model::PutLogEventsOutcome failedOutcome;
+    EXPECT_CALL(*mock_client_p, PutLogEvents(testing::_))
+        .WillOnce(testing::Return(failedOutcome));
+    Aws::String nextToken;
+
+    EXPECT_EQ(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_FAILED,
+        facade_->SendLogsToCloudWatch(nextToken, "", "", &logs_list_));
+}
+
+TEST_F(TestCloudWatchFacade, TestCWLogsFacade_SendLogsToCloudWatch_SuccessResponse)
+{
+    Aws::CloudWatchLogs::Model::PutLogEventsResult successResult;
+    Aws::CloudWatchLogs::Model::PutLogEventsOutcome successOutcome(successResult);
+    EXPECT_CALL(*mock_client_p, PutLogEvents(testing::_))
+        .WillOnce(testing::Return(successOutcome));
+    Aws::String nextToken;
+
+    EXPECT_EQ(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_SUCCEEDED,
+        facade_->SendLogsToCloudWatch(nextToken, "", "", &logs_list_));
+}
+
+TEST_F(TestCloudWatchFacade, TestCWLogsFacade_SendLogsToCloudWatch_LongSuccessResponse)
+{
+    Aws::CloudWatchLogs::Model::PutLogEventsResult successResult;
+    Aws::CloudWatchLogs::Model::PutLogEventsOutcome successOutcome(successResult);
+    EXPECT_CALL(*mock_client_p, PutLogEvents(testing::_))
+        .Times(2)
+        .WillRepeatedly(testing::Return(successOutcome));
+
+    Aws::String nextToken;
+    std::list<Aws::CloudWatchLogs::Model::InputLogEvent> logs_list;
+    for (int i=0;i<200;i++) {
+        logs_list.emplace_back();
+    }
+
+    EXPECT_EQ(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_SUCCEEDED,
+        facade_->SendLogsToCloudWatch(nextToken, "", "", &logs_list));
+}
+
+
+/*
+ * CreateLogGroup Tests
+ */
+
+TEST_F(TestCloudWatchFacade, TestCWLogsFacade_CreateLogGroup_SuccessResponse)
+{
+    Aws::CloudWatchLogs::Model::CreateLogGroupOutcome* successOutcome = 
+        new Aws::CloudWatchLogs::Model::CreateLogGroupOutcome(Aws::NoResult());
+
+    EXPECT_CALL(*mock_client_p, CreateLogGroup(testing::_))
+        .WillOnce(testing::Return(*successOutcome));
+
+    EXPECT_EQ(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_SUCCEEDED,
+        facade_->CreateLogGroup(LOG_GROUP_NAME1));
+}
+
+TEST_F(TestCloudWatchFacade, TestCWLogsFacade_CreateLogGroup_FailedResponse)
+{
+    Aws::CloudWatchLogs::Model::CreateLogGroupOutcome* failedOutcome =
+        new Aws::CloudWatchLogs::Model::CreateLogGroupOutcome();
+
+    EXPECT_CALL(*mock_client_p, CreateLogGroup(testing::_))
+        .WillOnce(testing::Return(*failedOutcome));
+
+    EXPECT_EQ(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_CREATE_LOG_GROUP_FAILED,
+        facade_->CreateLogGroup(LOG_GROUP_NAME1));
+}
+
+TEST_F(TestCloudWatchFacade, TestCWLogsFacade_CreateLogGroup_AlreadyExists)
+{
+    Aws::Client::AWSError<Aws::CloudWatchLogs::CloudWatchLogsErrors> error
+    (Aws::CloudWatchLogs::CloudWatchLogsErrors::RESOURCE_ALREADY_EXISTS, false);
+
+    Aws::CloudWatchLogs::Model::CreateLogGroupOutcome* failedOutcome =
+        new Aws::CloudWatchLogs::Model::CreateLogGroupOutcome(error);
+
+    EXPECT_CALL(*mock_client_p, CreateLogGroup(testing::_))
+        .WillOnce(testing::Return(*failedOutcome));
+
+    EXPECT_EQ(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_LOG_GROUP_ALREADY_EXISTS,
+        facade_->CreateLogGroup(LOG_GROUP_NAME1));
+}
+
+/*
+ * CheckLogGroupExists Tests
+ */
+
+TEST_F(TestCloudWatchFacade, TestCWLogsFacade_CheckLogGroupExists_FailedResponse)
+{
+    Aws::CloudWatchLogs::Model::DescribeLogGroupsOutcome failedOutcome;
+    EXPECT_CALL(*mock_client_p, DescribeLogGroups(testing::_))
+        .WillOnce(testing::Return(failedOutcome));
+
+    EXPECT_EQ(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_FAILED,
+        facade_->CheckLogGroupExists(LOG_GROUP_NAME1));
+}
+
+TEST_F(TestCloudWatchFacade, TestCWLogsFacade_CheckLogGroupExists_LogGroupExists)
+{
+    Aws::CloudWatchLogs::Model::LogGroup TestGroup;
+    TestGroup.SetLogGroupName(LOG_GROUP_NAME1);
+    Aws::CloudWatchLogs::Model::DescribeLogGroupsResult existsResult;
+    existsResult.AddLogGroups(TestGroup);
+    existsResult.SetNextToken("token");
+    Aws::CloudWatchLogs::Model::DescribeLogGroupsOutcome existsOutcome(existsResult);
+    EXPECT_CALL(*mock_client_p, DescribeLogGroups(testing::_))
+        .WillOnce(testing::Return(existsOutcome));
+    
+    EXPECT_EQ(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_SUCCEEDED,
+        facade_->CheckLogGroupExists(LOG_GROUP_NAME1));
+}
+
+TEST_F(TestCloudWatchFacade, TestCWLogsFacade_CheckLogGroupExists_LogGroupDoesntExist)
+{   Aws::CloudWatchLogs::Model::LogGroup TestGroup;
+    TestGroup.SetLogGroupName(LOG_GROUP_NAME1);
+    Aws::CloudWatchLogs::Model::DescribeLogGroupsResult doesntExistResult;
+    doesntExistResult.AddLogGroups(TestGroup);
+    doesntExistResult.SetNextToken("");
+    Aws::CloudWatchLogs::Model::DescribeLogGroupsOutcome doesntExistOutcome(doesntExistResult);
+    EXPECT_CALL(*mock_client_p, DescribeLogGroups(testing::_))
+        .WillOnce(testing::Return(doesntExistOutcome));
+
+    EXPECT_EQ(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_LOG_GROUP_NOT_FOUND,
+        facade_->CheckLogGroupExists(LOG_GROUP_NAME2));
+}
+
+/*
+ * CreateLogStream Tests
+ */
+
+TEST_F(TestCloudWatchFacade, TestCWLogsFacade_CreateLogStream_SuccessResponse)
+{
+    Aws::CloudWatchLogs::Model::CreateLogStreamOutcome* successOutcome =
+        new Aws::CloudWatchLogs::Model::CreateLogStreamOutcome(Aws::NoResult());
+
+    EXPECT_CALL(*mock_client_p, CreateLogStream(testing::_))
+        .WillOnce(testing::Return(*successOutcome));
+
+    EXPECT_EQ(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_SUCCEEDED,
+        facade_->CreateLogStream(LOG_GROUP_NAME1, LOG_STREAM_NAME1));
+}
+
+TEST_F(TestCloudWatchFacade, TestCWLogsFacade_CreateLogStream_FailedResponse)
+{
+    Aws::CloudWatchLogs::Model::CreateLogStreamOutcome* failedOutcome =
+        new Aws::CloudWatchLogs::Model::CreateLogStreamOutcome();
+
+    EXPECT_CALL(*mock_client_p, CreateLogStream(testing::_))
+        .WillOnce(testing::Return(*failedOutcome));
+
+    EXPECT_EQ(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_CREATE_LOG_STREAM_FAILED,
+        facade_->CreateLogStream(LOG_GROUP_NAME1, LOG_STREAM_NAME1));
+}
+
+TEST_F(TestCloudWatchFacade, TestCWLogsFacade_CreateLogStream_AlreadyExists)
+{
+    Aws::Client::AWSError<Aws::CloudWatchLogs::CloudWatchLogsErrors> error
+    (Aws::CloudWatchLogs::CloudWatchLogsErrors::RESOURCE_ALREADY_EXISTS, false);
+
+    Aws::CloudWatchLogs::Model::CreateLogStreamOutcome* failedOutcome =
+        new Aws::CloudWatchLogs::Model::CreateLogStreamOutcome(error);
+
+    EXPECT_CALL(*mock_client_p, CreateLogStream(testing::_))
+        .WillOnce(testing::Return(*failedOutcome));
+
+    EXPECT_EQ(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_LOG_STREAM_ALREADY_EXISTS,
+        facade_->CreateLogStream(LOG_GROUP_NAME1, LOG_STREAM_NAME1));
+}
+
+/*
+ * CheckLogStreamExists Tests
+ */
+
+TEST_F(TestCloudWatchFacade, TestCWLogsFacade_CheckLogStreamExists_FailedResponse)
+{
+    Aws::CloudWatchLogs::Model::DescribeLogStreamsOutcome failedOutcome;
+    Aws::CloudWatchLogs::Model::LogStream * log_stream_object;
+    EXPECT_CALL(*mock_client_p, DescribeLogStreams(testing::_))
+        .WillOnce(testing::Return(failedOutcome));
+
+    EXPECT_EQ(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_FAILED,
+        facade_->CheckLogStreamExists(LOG_GROUP_NAME1, LOG_STREAM_NAME1, log_stream_object));
+}
+
+TEST_F(TestCloudWatchFacade, TestCWLogsFacade_CheckLogStreamExists_LogStreamExists)
+{
+    Aws::CloudWatchLogs::Model::LogStream TestStream;
+    TestStream.SetLogStreamName(LOG_STREAM_NAME1);
+    Aws::CloudWatchLogs::Model::DescribeLogStreamsResult existsResult;
+    existsResult.AddLogStreams(TestStream);
+    existsResult.SetNextToken("token");
+    Aws::CloudWatchLogs::Model::DescribeLogStreamsOutcome existsOutcome(existsResult);
+    EXPECT_CALL(*mock_client_p, DescribeLogStreams(testing::_))
+        .WillOnce(testing::Return(existsOutcome));
+
+    Aws::CloudWatchLogs::Model::LogStream * log_stream_object = new Aws::CloudWatchLogs::Model::LogStream();
+    EXPECT_EQ(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_SUCCEEDED,
+        facade_->CheckLogStreamExists(LOG_GROUP_NAME1, LOG_STREAM_NAME1, log_stream_object));
+}
+
+
+TEST_F(TestCloudWatchFacade, TestCWLogsFacade_CheckLogStreamExists_LogStreamDoesntExist)
+{   Aws::CloudWatchLogs::Model::LogStream TestStream;
+    TestStream.SetLogStreamName(LOG_STREAM_NAME2);
+    Aws::CloudWatchLogs::Model::DescribeLogStreamsResult doesntExistResult;
+    doesntExistResult.AddLogStreams(TestStream);
+    //doesntExistResult.SetNextToken("");
+    Aws::CloudWatchLogs::Model::DescribeLogStreamsOutcome doesntExistOutcome(doesntExistResult);
+    EXPECT_CALL(*mock_client_p, DescribeLogStreams(testing::_))
+        .WillOnce(testing::Return(doesntExistOutcome));
+
+    Aws::CloudWatchLogs::Model::LogStream * log_stream_object;
+    EXPECT_EQ(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_LOG_STREAM_NOT_FOUND,
+        facade_->CheckLogStreamExists(LOG_GROUP_NAME1, LOG_STREAM_NAME1, log_stream_object));
+}

--- a/cloudwatch_logs_common/test/include/cloudwatch_logs_common/cloudwatch_logs_client_mock.h
+++ b/cloudwatch_logs_common/test/include/cloudwatch_logs_common/cloudwatch_logs_client_mock.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+#pragma once
+
+#include <gmock/gmock.h>
+#include <aws/core/Aws.h>
+#include <aws/core/utils/Outcome.h>
+#include <aws/core/client/AWSClient.h>
+#include <aws/logs/CloudWatchLogsClient.h>
+#include <aws/logs/model/CreateLogGroupRequest.h>
+#include <aws/logs/model/DescribeLogGroupsRequest.h>
+#include <aws/logs/model/CreateLogStreamRequest.h>
+#include <aws/logs/model/DescribeLogStreamsRequest.h>
+
+
+
+class CloudWatchLogsClientMock : public Aws::CloudWatchLogs::CloudWatchLogsClient
+{
+public:
+    MOCK_CONST_METHOD1(
+        PutLogEvents,
+        Aws::CloudWatchLogs::Model::PutLogEventsOutcome(
+            const Aws::CloudWatchLogs::Model::PutLogEventsRequest & request));
+    MOCK_CONST_METHOD1(
+        CreateLogGroup,
+        Aws::CloudWatchLogs::Model::CreateLogGroupOutcome(
+            const Aws::CloudWatchLogs::Model::CreateLogGroupRequest & request));
+    MOCK_CONST_METHOD1(
+        DescribeLogGroups,
+        Aws::CloudWatchLogs::Model::DescribeLogGroupsOutcome(
+            const Aws::CloudWatchLogs::Model::DescribeLogGroupsRequest & request));
+    MOCK_CONST_METHOD1(
+        CreateLogStream,
+        Aws::CloudWatchLogs::Model::CreateLogStreamOutcome(
+            const Aws::CloudWatchLogs::Model::CreateLogStreamRequest & request));
+    MOCK_CONST_METHOD1(
+        DescribeLogStreams,
+        Aws::CloudWatchLogs::Model::DescribeLogStreamsOutcome(
+            const Aws::CloudWatchLogs::Model::DescribeLogStreamsRequest & request));
+};
+

--- a/cloudwatch_logs_common/test/log_publisher_test.cpp
+++ b/cloudwatch_logs_common/test/log_publisher_test.cpp
@@ -45,6 +45,19 @@ public:
     this->send_logs_call_count = 0;
   }
 
+  Aws::CloudWatchLogs::ROSCloudWatchLogsErrors CheckLogGroupExists(
+    const std::string & log_group) override
+  {
+    return Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_SUCCEEDED;
+  }
+
+  Aws::CloudWatchLogs::ROSCloudWatchLogsErrors CheckLogStreamExists(
+    const std::string & log_group, const std::string & log_stream,
+    Aws::CloudWatchLogs::Model::LogStream * log_stream_object) override
+  {
+    return Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_SUCCEEDED;
+  }
+
   Aws::CloudWatchLogs::ROSCloudWatchLogsErrors CreateLogGroup(
     const std::string & log_group) override
   {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Moves CloudWatchLogs Client to being a shared pointer in CloudWatchFacade class to facilitate testing
- Adds unit tests for cloudwatch facade 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
