### PR TITLE
Get dependencies from rosdep instead of building from source.

### DIFF
--- a/cloudwatch_logs_common/package.xml
+++ b/cloudwatch_logs_common/package.xml
@@ -9,7 +9,7 @@
 
   <license>Apache 2.0</license>
 
-  <depend>aws_common</depend>
+  <depend version_lt='2.0.0'>aws_common</depend>
   <buildtool_depend>cmake</buildtool_depend>
   <test_depend>gtest</test_depend>
 

--- a/cloudwatch_metrics_common/package.xml
+++ b/cloudwatch_metrics_common/package.xml
@@ -10,7 +10,7 @@
   <license>Apache 2.0</license>
 
   <buildtool_depend>cmake</buildtool_depend>
-  <depend>aws_common</depend>
+  <depend version_lt='2.0.0'>aws_common</depend>
   <test_depend>gtest</test_depend>
 
   <export>


### PR DESCRIPTION
The release branch of cloud extension packages should take dependencies from rosdep(apt) instead of building from source

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
