### PR TITLE
Modify cloudwatch common to depend on gtest, gmock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
   global:
     - GITHUB_ACCOUNT=aws-robotics
     # uncomment PACKAGE_NAMES to build unit tests - REQUIRED if you'd like to run unit tests using colcon
-    # - PACKAGE_NAMES=
+    - PACKAGE_NAMES="cloudwatch_logs_common cloudwatch_metrics_common"
   matrix:
     - ROS_DISTRO=kinetic ROS_VERSION=1
     - ROS_DISTRO=melodic ROS_VERSION=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ notifications:
 env:
   global:
     - GITHUB_ACCOUNT=aws-robotics
+    # uncomment PACKAGE_NAMES to build unit tests - REQUIRED if you'd like to run unit tests using colcon
+    # - PACKAGE_NAMES=
   matrix:
     - ROS_DISTRO=kinetic ROS_VERSION=1
     - ROS_DISTRO=melodic ROS_VERSION=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,10 @@ env:
   matrix:
     - ROS_DISTRO=kinetic ROS_VERSION=1
     - ROS_DISTRO=melodic ROS_VERSION=1
-    - ROS_DISTRO=bouncy  ROS_VERSION=2
-    - ROS_DISTRO=crystal ROS_VERSION=2
+    - ROS_DISTRO=dashing ROS_VERSION=2
 matrix:
   allow_failures:
-    - env: ROS_DISTRO=bouncy  ROS_VERSION=2
-    - env: ROS_DISTRO=crystal ROS_VERSION=2
+    - env: ROS_DISTRO=dashing ROS_VERSION=2
 install:
   - git clone https://github.com/aws-robotics/travis-scripts.git .ros_ci
 script:

--- a/cloudwatch_logs_common/CMakeLists.txt
+++ b/cloudwatch_logs_common/CMakeLists.txt
@@ -4,15 +4,14 @@ set(CLOUDWATCH_LOGS_COMMON_VERSION 1.0.0)
 
 # Default to C11
 if(NOT CMAKE_C_STANDARD)
-    set(CMAKE_C_STANDARD 11)
+  set(CMAKE_C_STANDARD 11)
 endif()
 # Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 14)
 endif()
 
 find_package(aws_common REQUIRED)
-
 if(AWSSDK_FOUND)
   set(SERVICE logs)
   AWSSDK_DETERMINE_LIBS_TO_LINK(SERVICE OUTPUT)
@@ -25,8 +24,8 @@ add_library(${PROJECT_NAME} SHARED ${ALL_SRC_FILES})
 target_link_libraries(${PROJECT_NAME} ${OUTPUT})
 target_include_directories(${PROJECT_NAME} PRIVATE ${AWSSDK_INCLUDE_DIRS} include ${aws_common_INCLUDE_DIRS})
 target_include_directories(${PROJECT_NAME} PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-        $<INSTALL_INTERFACE:include>)
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>)
 
 
 #############
@@ -61,22 +60,21 @@ INSTALL(EXPORT ${PROJECT_NAME}-targets DESTINATION share/${PROJECT_NAME}/cmake)
 
 enable_testing()
 find_common_test_packages()
-if(GMOCK_LIBRARIES)
-  add_executable(test_cloudwatch_logs_common
-    test/main_test.cpp
-    test/shared_object_test.cpp
-    test/log_manager_test.cpp
-    test/log_publisher_test.cpp
-    test/cloudwatch_facade_test.cpp)
-  target_include_directories(test_cloudwatch_logs_common
-        PRIVATE include
-        PRIVATE ${aws_common_INCLUDE_DIRS}
-        PUBLIC ${PROJECT_SOURCE_DIR}/test/include
-        )
-  target_link_libraries(test_cloudwatch_logs_common
-        ${GTEST_LIBRARIES}
-        pthread
-        libgmock
-        ${PROJECT_NAME})
-  add_test(NAME test_cloudwatch_logs_common COMMAND test_cloudwatch_logs_common --gtest_output=xml:test_results/)
-endif()
+add_common_gtest(test_cloudwatch_logs_common
+  test/main_test.cpp
+  test/shared_object_test.cpp
+  test/log_manager_test.cpp
+  test/log_publisher_test.cpp
+  test/cloudwatch_facade_test.cpp
+)
+target_include_directories(test_cloudwatch_logs_common PRIVATE
+  include
+  ${aws_common_INCLUDE_DIRS}
+  ${PROJECT_SOURCE_DIR}/test/include
+)
+target_link_libraries(test_cloudwatch_logs_common
+  ${PROJECT_NAME}
+  ${aws_common_LIBRARIES}
+  ${GMOCK_LIBRARY}
+  pthread
+)

--- a/cloudwatch_logs_common/CMakeLists.txt
+++ b/cloudwatch_logs_common/CMakeLists.txt
@@ -12,6 +12,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 find_package(aws_common REQUIRED)
+
 if(AWSSDK_FOUND)
   set(SERVICE logs)
   AWSSDK_DETERMINE_LIBS_TO_LINK(SERVICE OUTPUT)
@@ -59,12 +60,8 @@ INSTALL(EXPORT ${PROJECT_NAME}-targets DESTINATION share/${PROJECT_NAME}/cmake)
 #############
 
 enable_testing()
-find_package(GTest QUIET)
-if(NOT GTEST_FOUND)
-  message(WARNING "Could not find GTest. Not building unit tests.")
-else()
-  include_directories(/usr/include/gmock /usr/src/gmock)
-  add_library(libgmock /usr/src/gmock/src/gmock-all.cc)
+find_common_test_packages()
+if(GMOCK_LIBRARIES)
   add_executable(test_cloudwatch_logs_common
     test/main_test.cpp
     test/shared_object_test.cpp

--- a/cloudwatch_logs_common/package.xml
+++ b/cloudwatch_logs_common/package.xml
@@ -10,6 +10,7 @@
   <license>Apache 2.0</license>
 
   <buildtool_depend>cmake</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
 
   <depend>aws_common</depend>
 

--- a/cloudwatch_logs_common/package.xml
+++ b/cloudwatch_logs_common/package.xml
@@ -9,9 +9,10 @@
 
   <license>Apache 2.0</license>
 
-  <depend>aws_common</depend>
   <buildtool_depend>cmake</buildtool_depend>
-  
+
+  <depend>aws_common</depend>
+
   <test_depend condition="$ROS_VERSION == 1">gtest</test_depend>
   <test_depend condition="$ROS_VERSION == 1">google-mock</test_depend>
   <test_depend condition="$ROS_VERSION == 2">ament_cmake_gtest</test_depend>

--- a/cloudwatch_logs_common/package.xml
+++ b/cloudwatch_logs_common/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>cloudwatch_logs_common</name>
   <version>1.0.2</version>
   <description>AWS CloudWatch management library used by ROS1/2 node to publish logs to CloudWatch service</description>
@@ -11,7 +11,11 @@
 
   <depend>aws_common</depend>
   <buildtool_depend>cmake</buildtool_depend>
-  <test_depend>gtest</test_depend>
+  
+  <test_depend condition="$ROS_VERSION == 1">gtest</test_depend>
+  <test_depend condition="$ROS_VERSION == 1">google-mock</test_depend>
+  <test_depend condition="$ROS_VERSION == 2">ament_cmake_gtest</test_depend>
+  <test_depend condition="$ROS_VERSION == 2">ament_cmake_gmock</test_depend>
 
   <export>
     <build_type>cmake</build_type>

--- a/cloudwatch_metrics_common/CMakeLists.txt
+++ b/cloudwatch_metrics_common/CMakeLists.txt
@@ -2,7 +2,14 @@ cmake_minimum_required(VERSION 2.8.3)
 project(cloudwatch_metrics_common)
 set(CLOUDWATCH_METRICS_COMMON_VERSION 1.0.0)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=c++14 ")
+# Default to C11
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 11)
+endif()
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
 
 find_package(aws_common REQUIRED)
 if(AWSSDK_FOUND)
@@ -13,7 +20,7 @@ endif()
 
 set(ALL_SRC_FILES src/utils/cloudwatch_facade.cpp src/metric_manager.cpp src/metric_manager_factory.cpp src/metric_publisher.cpp)
 
-add_library(${PROJECT_NAME} ${ALL_SRC_FILES})
+add_library(${PROJECT_NAME} SHARED ${ALL_SRC_FILES})
 target_link_libraries(${PROJECT_NAME} ${OUTPUT})
 target_include_directories(${PROJECT_NAME} PRIVATE ${aws_common_INCLUDE_DIRS} ${AWSSDK_INCLUDE_DIR})
 target_include_directories(${PROJECT_NAME} PUBLIC
@@ -27,21 +34,19 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 
 enable_testing()
 find_common_test_packages()
-if(GMOCK_LIBRARIES)
-  add_executable(test_cloudwatch_metrics_common
-    test/main_test.cpp
-    test/shared_object_test.cpp
-    test/metric_manager_test.cpp
-    test/metric_publisher_test.cpp)
-  target_include_directories(test_cloudwatch_metrics_common PRIVATE ${aws_common_INCLUDE_DIRS} ${AWSSDK_INCLUDE_DIR})
-  target_link_libraries(test_cloudwatch_metrics_common
-    ${GTEST_LIBRARIES}
-    pthread
-    ${aws_common_LIBRARIES}
-    ${PROJECT_NAME}
-    ${rclcpp_LIBRARIES})
-  add_test(NAME test_cloudwatch_metrics_common COMMAND test_cloudwatch_metrics_common --gtest_output=xml:test_results/)
-endif()
+add_common_gtest(test_cloudwatch_metrics_common
+  test/main_test.cpp
+  test/shared_object_test.cpp
+  test/metric_manager_test.cpp
+  test/metric_publisher_test.cpp
+)
+target_link_libraries(test_cloudwatch_metrics_common
+  ${PROJECT_NAME}
+  ${aws_common_LIBRARIES}
+  ${GMOCK_LIBRARY}
+  pthread
+)
+
 
 #############
 ## Install ##

--- a/cloudwatch_metrics_common/CMakeLists.txt
+++ b/cloudwatch_metrics_common/CMakeLists.txt
@@ -26,10 +26,8 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 #############
 
 enable_testing()
-find_package(GTest QUIET)
-if(NOT GTEST_FOUND)
-  message(WARNING "Could not find GTest. Not building unit tests.")
-else()
+find_common_test_packages()
+if(GMOCK_LIBRARIES)
   add_executable(test_cloudwatch_metrics_common
     test/main_test.cpp
     test/shared_object_test.cpp

--- a/cloudwatch_metrics_common/package.xml
+++ b/cloudwatch_metrics_common/package.xml
@@ -10,6 +10,7 @@
   <license>Apache 2.0</license>
 
   <buildtool_depend>cmake</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
 
   <depend>aws_common</depend>
 

--- a/cloudwatch_metrics_common/package.xml
+++ b/cloudwatch_metrics_common/package.xml
@@ -10,8 +10,9 @@
   <license>Apache 2.0</license>
 
   <buildtool_depend>cmake</buildtool_depend>
+
   <depend>aws_common</depend>
-  
+
   <test_depend condition="$ROS_VERSION == 1">gtest</test_depend>
   <test_depend condition="$ROS_VERSION == 1">google-mock</test_depend>
   <test_depend condition="$ROS_VERSION == 2">ament_cmake_gtest</test_depend>

--- a/cloudwatch_metrics_common/package.xml
+++ b/cloudwatch_metrics_common/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>cloudwatch_metrics_common</name>
   <version>1.0.2</version>
   <description>Library used by ROS1/2 node to publish metrics</description>
@@ -11,7 +11,11 @@
 
   <buildtool_depend>cmake</buildtool_depend>
   <depend>aws_common</depend>
-  <test_depend>gtest</test_depend>
+  
+  <test_depend condition="$ROS_VERSION == 1">gtest</test_depend>
+  <test_depend condition="$ROS_VERSION == 1">google-mock</test_depend>
+  <test_depend condition="$ROS_VERSION == 2">ament_cmake_gtest</test_depend>
+  <test_depend condition="$ROS_VERSION == 2">ament_cmake_gmock</test_depend>
 
   <export>
     <build_type>cmake</build_type>


### PR DESCRIPTION
Use the macro in aws_common to find test dependencies for ROS1 or ROS2.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
