### PR TITLE
Increase test timeout to fix flakiness

### DIFF
--- a/cloudwatch_logs_common/test/log_publisher_test.cpp
+++ b/cloudwatch_logs_common/test/log_publisher_test.cpp
@@ -23,7 +23,7 @@
 using namespace Aws::CloudWatchLogs;
 
 constexpr int WAIT_TIME =
-  2000;  // the amount of time (ms) to wait for publisher thread to do its work
+  5000;  // the amount of time (ms) to wait for publisher thread to do its work
 
 class MockCloudWatchFacade : public Aws::CloudWatchLogs::Utils::CloudWatchFacade
 {


### PR DESCRIPTION
- Increase the test timeout to 5000ms because sometimes SendLogsToCloudWatch isn't being called fast enough and so the tests fail. 

Issue: Internal Ticket V117830572 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
