### PR TITLE
Remove -Wcast-align flag to support ARMhf builds

### DIFF
--- a/cloudwatch_logs_common/CMakeLists.txt
+++ b/cloudwatch_logs_common/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 # Enable strict compiler flags if possible.
 include(CheckCXXCompilerFlag)
 # Removed -Wmissing-declarations until gmock is ignored
-set(FLAGS -pedantic -Wno-long-long -Wall -Wextra -Wcast-align -Wcast-qual -Wformat -Wwrite-strings)
+set(FLAGS -pedantic -Wno-long-long -Wall -Wextra -Wcast-qual -Wformat -Wwrite-strings)
 foreach(FLAG ${FLAGS})
   check_cxx_compiler_flag(${FLAG} R${FLAG})
   if(${R${FLAG}})

--- a/cloudwatch_logs_common/CMakeLists.txt
+++ b/cloudwatch_logs_common/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 # Enable strict compiler flags if possible.
 include(CheckCXXCompilerFlag)
 # Removed -Wmissing-declarations until gmock is ignored
-set(FLAGS -pedantic -Wno-long-long -Wall -Wextra -Wcast-qual -Wformat -Wwrite-strings -Werror -Wcast-align -Wno-error=cast-align)
+set(FLAGS -pedantic -Wno-long-long -Wall -Wextra -Wcast-qual -Wformat -Wwrite-strings -Wcast-align -Wno-error=cast-align)
 foreach(FLAG ${FLAGS})
   check_cxx_compiler_flag(${FLAG} R${FLAG})
   if(${R${FLAG}})

--- a/cloudwatch_logs_common/CMakeLists.txt
+++ b/cloudwatch_logs_common/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 # Enable strict compiler flags if possible.
 include(CheckCXXCompilerFlag)
 # Removed -Wmissing-declarations until gmock is ignored
-set(FLAGS -pedantic -Wno-long-long -Wall -Wextra -Wcast-qual -Wformat -Wwrite-strings)
+set(FLAGS -pedantic -Wno-long-long -Wall -Wextra -Wcast-qual -Wformat -Wwrite-strings -Werror -Wcast-align -Wno-error=cast-align)
 foreach(FLAG ${FLAGS})
   check_cxx_compiler_flag(${FLAG} R${FLAG})
   if(${R${FLAG}})

--- a/cloudwatch_logs_common/package.xml
+++ b/cloudwatch_logs_common/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>cloudwatch_logs_common</name>
-  <version>1.1.0</version>
+  <version>1.1.1</version>
   <description>AWS CloudWatch management library used by ROS1/2 node to publish logs to CloudWatch service</description>
 
   <author email="ros-contributions@amazon.com">AWS RoboMaker</author>

--- a/cloudwatch_metrics_common/CMakeLists.txt
+++ b/cloudwatch_metrics_common/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 # Enable strict compiler flags if possible.
 include(CheckCXXCompilerFlag)
 # Removed -Wmissing-declarations until gmock is ignored
-set(FLAGS -pedantic -Wno-long-long -Wall -Wextra -Wcast-align -Wcast-qual -Wformat -Wwrite-strings)
+set(FLAGS -pedantic -Wno-long-long -Wall -Wextra -Wcast-qual -Wformat -Wwrite-strings)
 foreach(FLAG ${FLAGS})
   check_cxx_compiler_flag(${FLAG} R${FLAG})
   if(${R${FLAG}})

--- a/cloudwatch_metrics_common/CMakeLists.txt
+++ b/cloudwatch_metrics_common/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 # Enable strict compiler flags if possible.
 include(CheckCXXCompilerFlag)
 # Removed -Wmissing-declarations until gmock is ignored
-set(FLAGS -pedantic -Wno-long-long -Wall -Wextra -Wcast-qual -Wformat -Wwrite-strings -Werror -Wcast-align -Wno-error=cast-align)
+set(FLAGS -pedantic -Wno-long-long -Wall -Wextra -Wcast-qual -Wformat -Wwrite-strings -Wcast-align -Wno-error=cast-align)
 foreach(FLAG ${FLAGS})
   check_cxx_compiler_flag(${FLAG} R${FLAG})
   if(${R${FLAG}})

--- a/cloudwatch_metrics_common/CMakeLists.txt
+++ b/cloudwatch_metrics_common/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 # Enable strict compiler flags if possible.
 include(CheckCXXCompilerFlag)
 # Removed -Wmissing-declarations until gmock is ignored
-set(FLAGS -pedantic -Wno-long-long -Wall -Wextra -Wcast-qual -Wformat -Wwrite-strings)
+set(FLAGS -pedantic -Wno-long-long -Wall -Wextra -Wcast-qual -Wformat -Wwrite-strings -Werror -Wcast-align -Wno-error=cast-align)
 foreach(FLAG ${FLAGS})
   check_cxx_compiler_flag(${FLAG} R${FLAG})
   if(${R${FLAG}})

--- a/cloudwatch_metrics_common/package.xml
+++ b/cloudwatch_metrics_common/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>cloudwatch_metrics_common</name>
-  <version>1.1.0</version>
+  <version>1.1.1</version>
   <description>Library used by ROS1/2 node to publish metrics</description>
 
   <author email="ros-contributions@amazon.com">AWS RoboMaker</author>

--- a/dataflow_lite/CMakeLists.txt
+++ b/dataflow_lite/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 # Enable strict compiler flags if possible.
 include(CheckCXXCompilerFlag)
 # Removed -Wmissing-declarations until gmock is ignored
-set(FLAGS -pedantic -Wno-long-long -Wall -Wextra -Wcast-align -Wcast-qual -Wformat -Wwrite-strings)
+set(FLAGS -pedantic -Wno-long-long -Wall -Wextra -Wcast-qual -Wformat -Wwrite-strings)
 foreach(FLAG ${FLAGS})
   check_cxx_compiler_flag(${FLAG} R${FLAG})
   if(${R${FLAG}})

--- a/dataflow_lite/CMakeLists.txt
+++ b/dataflow_lite/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 # Enable strict compiler flags if possible.
 include(CheckCXXCompilerFlag)
 # Removed -Wmissing-declarations until gmock is ignored
-set(FLAGS -pedantic -Wno-long-long -Wall -Wextra -Wcast-qual -Wformat -Wwrite-strings -Werror -Wcast-align -Wno-error=cast-align)
+set(FLAGS -pedantic -Wno-long-long -Wall -Wextra -Wcast-qual -Wformat -Wwrite-strings -Wcast-align -Wno-error=cast-align)
 foreach(FLAG ${FLAGS})
   check_cxx_compiler_flag(${FLAG} R${FLAG})
   if(${R${FLAG}})

--- a/dataflow_lite/CMakeLists.txt
+++ b/dataflow_lite/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 # Enable strict compiler flags if possible.
 include(CheckCXXCompilerFlag)
 # Removed -Wmissing-declarations until gmock is ignored
-set(FLAGS -pedantic -Wno-long-long -Wall -Wextra -Wcast-qual -Wformat -Wwrite-strings)
+set(FLAGS -pedantic -Wno-long-long -Wall -Wextra -Wcast-qual -Wformat -Wwrite-strings -Werror -Wcast-align -Wno-error=cast-align)
 foreach(FLAG ${FLAGS})
   check_cxx_compiler_flag(${FLAG} R${FLAG})
   if(${R${FLAG}})

--- a/dataflow_lite/include/dataflow_lite/utils/observable_object.h
+++ b/dataflow_lite/include/dataflow_lite/utils/observable_object.h
@@ -23,9 +23,6 @@
 #include <memory>
 #include <mutex>
 
-#include <aws/core/Aws.h>
-#include <aws/core/utils/logging/LogMacros.h>
-
 /**
  * Class used as an atomic container of type T. Provides a listener registration and
  * broadcast mechanism for this container's updates.

--- a/dataflow_lite/include/dataflow_lite/utils/service.h
+++ b/dataflow_lite/include/dataflow_lite/utils/service.h
@@ -24,7 +24,6 @@
 #include <typeinfo>
 
 #include <dataflow_lite/utils/observable_object.h>
-#include <aws/core/utils/logging/LogMacros.h>
 
 enum ServiceState {
     CREATED,  // created and ready to start

--- a/dataflow_lite/package.xml
+++ b/dataflow_lite/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>dataflow_lite</name>
-  <version>1.1.0</version>
+  <version>1.1.1</version>
   <description>Light version of dataflow libraries</description>
 
   <author email="ros-contributions@amazon.com">AWS RoboMaker</author>

--- a/dataflow_lite/test/utils/data_batcher_test.cpp
+++ b/dataflow_lite/test/utils/data_batcher_test.cpp
@@ -22,7 +22,7 @@
 #include <stdexcept>
 
 /**
- * Simple extension to test basic funtionality
+ * Simple extension to test basic functionality
  */
 class TestBatcher : public DataBatcher<int> {
 public:

--- a/file_management/CMakeLists.txt
+++ b/file_management/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 # Enable strict compiler flags if possible.
 include(CheckCXXCompilerFlag)
 # Removed -Wmissing-declarations until gmock is ignored
-set(FLAGS -pedantic -Wno-long-long -Wall -Wextra -Wcast-align -Wcast-qual -Wformat -Wwrite-strings)
+set(FLAGS -pedantic -Wno-long-long -Wall -Wextra -Wcast-qual -Wformat -Wwrite-strings)
 foreach(FLAG ${FLAGS})
   check_cxx_compiler_flag(${FLAG} R${FLAG})
   if(${R${FLAG}})

--- a/file_management/CMakeLists.txt
+++ b/file_management/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 # Enable strict compiler flags if possible.
 include(CheckCXXCompilerFlag)
 # Removed -Wmissing-declarations until gmock is ignored
-set(FLAGS -pedantic -Wno-long-long -Wall -Wextra -Wcast-qual -Wformat -Wwrite-strings -Werror -Wcast-align -Wno-error=cast-align)
+set(FLAGS -pedantic -Wno-long-long -Wall -Wextra -Wcast-qual -Wformat -Wwrite-strings -Wcast-align -Wno-error=cast-align)
 foreach(FLAG ${FLAGS})
   check_cxx_compiler_flag(${FLAG} R${FLAG})
   if(${R${FLAG}})

--- a/file_management/CMakeLists.txt
+++ b/file_management/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 # Enable strict compiler flags if possible.
 include(CheckCXXCompilerFlag)
 # Removed -Wmissing-declarations until gmock is ignored
-set(FLAGS -pedantic -Wno-long-long -Wall -Wextra -Wcast-qual -Wformat -Wwrite-strings)
+set(FLAGS -pedantic -Wno-long-long -Wall -Wextra -Wcast-qual -Wformat -Wwrite-strings -Werror -Wcast-align -Wno-error=cast-align)
 foreach(FLAG ${FLAGS})
   check_cxx_compiler_flag(${FLAG} R${FLAG})
   if(${R${FLAG}})

--- a/file_management/package.xml
+++ b/file_management/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>file_management</name>
-  <version>1.1.0</version>
+  <version>1.1.1</version>
   <description>AWS CloudWatch management library used to manage offline files.</description>
 
   <author email="ros-contributions@amazon.com">AWS RoboMaker</author>


### PR DESCRIPTION
Support ARMhf builds by removing the -Wcast-align flag. This flag should be removed due to the build issues with the aws sdk dependency.

See http://build.ros2.org/job/Dbin_ubhf_uBhf__dataflow_lite__ubuntu_bionic_armhf__binary/1/ for an example of a build failure.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
