### PR TITLE
Fixes a bug where we did not null check the result of getting the HOM…

### DIFF
--- a/file_management/include/file_management/file_upload/file_manager_strategy.h
+++ b/file_management/include/file_management/file_upload/file_manager_strategy.h
@@ -44,6 +44,14 @@ static constexpr const char* kEofKey = "eof";
 static constexpr const char* kFilePathKey = "file_path";
 
 /**
+ * Sanitizes the path provided by making sure it ends with a '/' character
+ * and also replacing the '~', if it's at the front of the string, with the
+ * value of the $HOME environment variable. If $HOME is not set it attempts 
+ * to use $ROS_HOME. If niether is set then it throws a runtime exception.
+ */
+void sanitizePath(std::string & path);
+
+/**
  * Stores file token information for the purpose of tracking read locations.
  */
 class FileTokenInfo {

--- a/file_management/test/file_management/file_manager_strategy_test.cpp
+++ b/file_management/test/file_management/file_manager_strategy_test.cpp
@@ -288,7 +288,19 @@ TEST_F(FileManagerStrategyTest, on_storage_limit_delete_oldest_file) {
   }
 }
 
-TEST_F(FileManagerStrategyTest, sanitizePath_home_set) {
+class SanitizePathTest : public ::testing::Test {
+public:
+  void SetUp() override
+  {
+  }
+
+  void TearDown() override
+  {
+  }
+
+};
+
+TEST_F(SanitizePathTest, sanitizePath_home_set) {
   std::string test_path = "~/dir/";
   char * original_home = getenv("HOME");
   setenv("HOME", "/home", 1);
@@ -305,7 +317,7 @@ TEST_F(FileManagerStrategyTest, sanitizePath_home_set) {
   EXPECT_STREQ(test_path.c_str(), "/home/dir/");
 }
 
-TEST_F(FileManagerStrategyTest, sanitizePath_home_not_set_roshome_set) {
+TEST_F(SanitizePathTest, sanitizePath_home_not_set_roshome_set) {
   std::string test_path = "~/dir/";
   char * original_home = getenv("HOME");
   char * original_ros_home = getenv("ROS_HOME");
@@ -328,7 +340,7 @@ TEST_F(FileManagerStrategyTest, sanitizePath_home_not_set_roshome_set) {
 }
 
 
-TEST_F(FileManagerStrategyTest, sanitizePath_home_not_set_roshome_not_set) {
+TEST_F(SanitizePathTest, sanitizePath_home_not_set_roshome_not_set) {
   std::string test_path = "~/dir/";
   char * original_home = getenv("HOME");
   char * original_ros_home = getenv("ROS_HOME");
@@ -348,7 +360,7 @@ TEST_F(FileManagerStrategyTest, sanitizePath_home_not_set_roshome_not_set) {
 
 }
 
-TEST_F(FileManagerStrategyTest, sanitizePath_adds_trailing_slash) {
+TEST_F(SanitizePathTest, sanitizePath_adds_trailing_slash) {
   std::string test_path = "/test/path";
   sanitizePath(test_path);
   EXPECT_STREQ(test_path.c_str(), "/test/path/");

--- a/file_management/test/file_management/file_manager_strategy_test.cpp
+++ b/file_management/test/file_management/file_manager_strategy_test.cpp
@@ -18,6 +18,7 @@
 #include <iostream>
 #include <fstream>
 #include <cstdio>
+#include <cstdlib>
 #include <chrono>
 #include <thread>
 #include <experimental/filesystem>
@@ -285,4 +286,66 @@ TEST_F(FileManagerStrategyTest, on_storage_limit_delete_oldest_file) {
       EXPECT_TRUE(file_path != file_to_be_deleted);
     }
   }
+}
+
+TEST_F(FileManagerStrategyTest, sanitizePath_home_set) {
+  std::string test_path = "~/dir/";
+  char * original_home = getenv("HOME");
+  setenv("HOME", "/home", 1);
+
+  sanitizePath(test_path);
+
+  // Cleanup before test
+  if (NULL != original_home) {
+    setenv("HOME", original_home, 1);
+  }
+
+  EXPECT_STREQ(test_path.c_str(), "/home/dir/");
+}
+
+TEST_F(FileManagerStrategyTest, sanitizePath_home_not_set_roshome_set) {
+  std::string test_path = "~/dir/";
+  char * original_home = getenv("HOME");
+  char * original_ros_home = getenv("ROS_HOME");
+  unsetenv("HOME");
+  setenv("ROS_HOME", "/ros_home", 1);
+
+  sanitizePath(test_path);
+
+  // Cleanup before test
+  if (NULL != original_home) {
+    setenv("HOME", original_home, 1);
+  }
+  if (NULL != original_ros_home) {
+    setenv("ROS_HOME", original_ros_home, 1);
+  }
+
+  EXPECT_STREQ(test_path.c_str(), "/ros_home/dir/");
+}
+
+
+TEST_F(FileManagerStrategyTest, sanitizePath_home_not_set_roshome_not_set) {
+  std::string test_path = "~/dir/";
+  char * original_home = getenv("HOME");
+  char * original_ros_home = getenv("ROS_HOME");
+  unsetenv("HOME");
+  unsetenv("ROS_HOME");
+
+
+  ASSERT_THROW(sanitizePath(test_path), std::runtime_error);
+
+  // Cleanup before test
+  if (NULL != original_home) {
+    setenv("HOME", original_home, 1);
+  }
+  if (NULL != original_ros_home) {
+    setenv("ROS_HOME", original_ros_home, 1);
+  }
+
+}
+
+TEST_F(FileManagerStrategyTest, sanitizePath_adds_trailing_slash) {
+  std::string test_path = "/test/path";
+  sanitizePath(test_path);
+  EXPECT_STREQ(test_path.c_str(), "/test/path/");
 }

--- a/file_management/test/file_management/file_manager_strategy_test.cpp
+++ b/file_management/test/file_management/file_manager_strategy_test.cpp
@@ -298,6 +298,8 @@ TEST_F(FileManagerStrategyTest, sanitizePath_home_set) {
   // Cleanup before test
   if (NULL != original_home) {
     setenv("HOME", original_home, 1);
+  } else {
+    unsetenv("HOME");
   }
 
   EXPECT_STREQ(test_path.c_str(), "/home/dir/");
@@ -318,6 +320,8 @@ TEST_F(FileManagerStrategyTest, sanitizePath_home_not_set_roshome_set) {
   }
   if (NULL != original_ros_home) {
     setenv("ROS_HOME", original_ros_home, 1);
+  } else {
+    unsetenv("ROS_HOME");
   }
 
   EXPECT_STREQ(test_path.c_str(), "/ros_home/dir/");


### PR DESCRIPTION
…E env variable and also switches to create_directories instead of create_directory so that it doesn't SIGABRT when asked to create multiple levels of a directory.

*Issue #, if available:*
P30188761

*Description of changes:*
Fixes two bugs in the file manager. The first is that we weren't checking for a null return when getting the HOME environment variable. This caused us to segfault when deploying with robomaker because there was no HOME environment variable set. We'll now attempt to fallback to ROS_HOME so that we can continue to work by default with our existing releases. The second bug is that we use the create_directory function instead of create_directories, which causes a SIGABRT in cases where it needs to create multiple levels of a directory. 

I've tested this change by manually building, bundling, and deploying via RoboMaker to confirm it now works. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
