### PR TITLE
 Test the use of non-root build scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,6 @@ env:
     - ROS_DISTRO=melodic ROS_VERSION=1
     - ROS_DISTRO=dashing ROS_VERSION=2
 install:
-  - git clone https://github.com/aws-robotics/travis-scripts.git .ros_ci
+  - git clone https://github.com/aws-robotics/travis-scripts.git -b non-root .ros_ci
 script:
   - .ros_ci/ce_build.sh


### PR DESCRIPTION
*Description of changes:*

We want to build the cloud extensions in the docker container (similarly to the sample apps, like in https://github.com/aws-robotics/aws-robomaker-sample-application-objecttracker/pull/75 and https://github.com/aws-robotics/aws-robomaker-sample-application-objecttracker/pull/76) as a non-root user to better reflect real-world usage.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
