### PR TITLE
Add support for Cloudwatch MetricDatum StatisticSet

### DIFF
--- a/cloudwatch_metrics_common/include/cloudwatch_metrics_common/utils/metric_object.h
+++ b/cloudwatch_metrics_common/include/cloudwatch_metrics_common/utils/metric_object.h
@@ -141,7 +141,7 @@ static MetricDatum metricObjectToDatum(const MetricObject &metrics, const int64_
     Aws::CloudWatch::Model::Dimension dimension;
     Aws::String name(it->first.c_str());
     Aws::String d_value(it->second.c_str());
-    dimension.WithName(name.c_str()).WithValue(d_value);
+    dimension.WithName(name).WithValue(d_value);
     datum.AddDimensions(dimension);
   }
 

--- a/cloudwatch_metrics_common/include/cloudwatch_metrics_common/utils/metric_object.h
+++ b/cloudwatch_metrics_common/include/cloudwatch_metrics_common/utils/metric_object.h
@@ -59,6 +59,16 @@ enum class StatisticValuesType
  * userland provided metric data instead of using the AWS SDK specific object.
  */
 struct MetricObject {
+  /**
+   * Construct a new instance of MetricObject that contains a scalar value.
+   *
+   * @param _name metric name
+   * @param _value metric scalar value
+   * @param _unit metric unit
+   * @param _timestamp metric time stamp
+   * @param _dimensions dimensions delineating extra details about the metric
+   * @param _storage_resolution
+   */
   MetricObject(
     const std::string & _name,
     const double _value,
@@ -69,6 +79,16 @@ struct MetricObject {
     : metric_name(_name), unit(_unit), timestamp(_timestamp), value(_value),
       dimensions(_dimensions), storage_resolution(_storage_resolution) {}
 
+  /**
+   * Construct a new instance of MetricObject that contains a statistical values.
+   *
+   * @param _name metric name
+   * @param _statistic_values statistical values of the metric
+   * @param _unit metric unit
+   * @param _timestamp metric time stamp
+   * @param _dimensions dimensions delineating extra details about the metric
+   * @param _storage_resolution
+   */
   MetricObject(
     const std::string & _name,
     const std::map<StatisticValuesType, double> & _statistic_values,

--- a/cloudwatch_metrics_common/include/cloudwatch_metrics_common/utils/metric_object.h
+++ b/cloudwatch_metrics_common/include/cloudwatch_metrics_common/utils/metric_object.h
@@ -13,7 +13,6 @@
  * permissions and limitations under the License.
  */
 
-#include <limits>
 #include <list>
 #include <map>
 #include <string>
@@ -57,14 +56,9 @@ enum class StatisticValuesType
 
 /**
  * Wrapper object for the AWS specific Aws::CloudWatch::Model::MetricDatum. This object is meant to be constructed from
- * userland provided metric data instead of using the AWS SKD specific object.
+ * userland provided metric data instead of using the AWS SDK specific object.
  */
 struct MetricObject {
-  MetricObject()
-    : timestamp(std::numeric_limits<int64_t>::lowest()),
-      value(std::numeric_limits<double>::quiet_NaN()),
-      storage_resolution(std::numeric_limits<int>::lowest()) {}
-
   MetricObject(
     const std::string & _name,
     const double _value,
@@ -98,8 +92,6 @@ struct MetricObject {
 
 /**
  * Helper method to constructor an Aws::CloudWatch::Model::MetricDatum from a MetricObject.
- *
- * Note: currently this does not support statistics data
  *
  * @param metrics input MetricObject
  * @param timestamp

--- a/cloudwatch_metrics_common/test/metric_pipeline_test.cpp
+++ b/cloudwatch_metrics_common/test/metric_pipeline_test.cpp
@@ -184,10 +184,11 @@ MetricObject createTestMetricObject(
         const double value = 2.42,
         const std::string & unit = "gigawatts",
         const int64_t timestamp = 1234,
+        const std::map<StatisticValuesType, double> & statistic_values = std::map<StatisticValuesType, double>(),
         const std::map<std::string, std::string> & dimensions = std::map<std::string, std::string>(),
         const int storage_resolution = 60
         ) {
-  return MetricObject {name, value, unit, timestamp, dimensions, storage_resolution};
+  return MetricObject{name, unit, timestamp, value, statistic_values, dimensions, storage_resolution};
 }
 
 TEST_F(PipelineTest, Sanity) {

--- a/cloudwatch_metrics_common/test/metric_pipeline_test.cpp
+++ b/cloudwatch_metrics_common/test/metric_pipeline_test.cpp
@@ -184,6 +184,17 @@ MetricObject createTestMetricObject(
         const double value = 2.42,
         const std::string & unit = "gigawatts",
         const int64_t timestamp = 1234,
+        const std::map<std::string, std::string> & dimensions = std::map<std::string, std::string>(),
+        const int storage_resolution = 60
+        ) {
+  return MetricObject {name, value, unit, timestamp, dimensions, storage_resolution};
+}
+
+MetricObject createTestMetricObjectWithStatistics(
+        const std::string & name,
+        const double value = 2.42,
+        const std::string & unit = "gigawatts",
+        const int64_t timestamp = 1234,
         const std::map<StatisticValuesType, double> & statistic_values = std::map<StatisticValuesType, double>(),
         const std::map<std::string, std::string> & dimensions = std::map<std::string, std::string>(),
         const int storage_resolution = 60
@@ -215,7 +226,7 @@ TEST_F(PipelineTest, TestConvertToBatchedData) {
   const std::string dimension_name = "blah";
   const std::string dimension_value = "blah blah";
 
-  auto object = createTestMetricObject(metric_name);
+  auto object = createTestMetricObjectWithStatistics(metric_name);
   object.unit = "percent";
   object.statistic_values[StatisticValuesType::SUM] = 111.1;
   object.statistic_values[StatisticValuesType::SAMPLE_COUNT] = 24;


### PR DESCRIPTION
*Description of changes:*

This change is required by https://github.com/aws-robotics/cloudwatchmetrics-ros2/pull/14.

It adds support for making use of `Aws::CloudWatch::Model::StatisticSet`, which would make `MetricObject` structurally more similar to `metrics_statistics_msgs::msg::MetricsMessage`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
