### PR TITLE
Fix linting issues found by clang-tidy 6.0

### DIFF
--- a/cloudwatch_logs_common/include/cloudwatch_logs_common/cloudwatch_options.h
+++ b/cloudwatch_logs_common/include/cloudwatch_logs_common/cloudwatch_options.h
@@ -25,10 +25,16 @@ namespace CloudWatchLogs {
  * in one options object.
  */
 struct CloudWatchOptions {
+  CloudWatchOptions() = default;
+
+  CloudWatchOptions(const Aws::DataFlow::UploaderOptions & _uploader_options,
+                    Aws::FileManagement::FileManagerStrategyOptions _strategy_options)
+    : uploader_options(_uploader_options), file_manager_strategy_options(std::move(_strategy_options)) {}
+
   /**
    * All options for the FileUpload system
    */
-  Aws::DataFlow::UploaderOptions uploader_options;
+  Aws::DataFlow::UploaderOptions uploader_options{};
   /**
    * All options for the FileManager system
    */

--- a/cloudwatch_logs_common/include/cloudwatch_logs_common/log_batcher.h
+++ b/cloudwatch_logs_common/include/cloudwatch_logs_common/log_batcher.h
@@ -54,7 +54,7 @@ public:
   /**
    *  @brief Tears down a LogBatcher object
    */
-  virtual ~LogBatcher();
+  ~LogBatcher() override;
 
   /**
    *  @brief Services the log manager by performing periodic tasks when called.
@@ -63,13 +63,13 @@ public:
    *
    *  @return true of the data was succesfully published, false otherwise
    */
-  virtual bool publishBatchedData() override;
+  bool publishBatchedData() override;
 
   /**
    * Override default behavior to attempt to write to file to disk when emptying the collection.
    */
-  virtual void emptyCollection() override;
-  virtual bool start() override;
+  void emptyCollection() override;
+  bool start() override;
 
   /**
    * Set the log file manager, used for task publishing failures (write to disk if unable to send to CloudWatch).

--- a/cloudwatch_logs_common/include/cloudwatch_logs_common/log_batcher.h
+++ b/cloudwatch_logs_common/include/cloudwatch_logs_common/log_batcher.h
@@ -51,6 +51,10 @@ public:
   explicit LogBatcher(size_t max_allowable_batch_size = DataBatcher::kDefaultMaxBatchSize,
                       size_t publish_trigger_size = DataBatcher::kDefaultTriggerSize);
 
+  LogBatcher(const LogBatcher & other) = delete;
+
+  LogBatcher & operator=(const LogBatcher & other) = delete;
+
   /**
    *  @brief Tears down a LogBatcher object
    */

--- a/cloudwatch_logs_common/include/cloudwatch_logs_common/log_publisher.h
+++ b/cloudwatch_logs_common/include/cloudwatch_logs_common/log_publisher.h
@@ -78,15 +78,15 @@ public:
   /**
    *  @brief Tears down the LogPublisher object
    */
-  virtual ~LogPublisher();
+  ~LogPublisher() override;
 
-  virtual bool shutdown() override;
+  bool shutdown() override;
 
   /**
    * Create the cloudwatch facade
    * @return
    */
-  virtual bool start() override;
+  bool start() override;
 
   LogPublisherRunState getRunState();
 

--- a/cloudwatch_logs_common/include/cloudwatch_logs_common/log_publisher.h
+++ b/cloudwatch_logs_common/include/cloudwatch_logs_common/log_publisher.h
@@ -75,6 +75,10 @@ public:
   LogPublisher(const std::string & log_group, const std::string & log_stream,
                std::shared_ptr<Aws::CloudWatchLogs::Utils::CloudWatchLogsFacade> cw_client);
 
+  LogPublisher(const LogPublisher & other) = delete;
+
+  LogPublisher & operator=(const LogPublisher & other) = delete;
+
   /**
    *  @brief Tears down the LogPublisher object
    */

--- a/cloudwatch_logs_common/include/cloudwatch_logs_common/log_service.h
+++ b/cloudwatch_logs_common/include/cloudwatch_logs_common/log_service.h
@@ -32,6 +32,7 @@
 #include <chrono>
 #include <stdexcept>
 #include <string>
+#include <utility>
 
 namespace Aws {
 namespace CloudWatchLogs {
@@ -58,9 +59,9 @@ public:
   LogService(std::shared_ptr<Publisher<LogCollection>> log_publisher,
              std::shared_ptr<DataBatcher<LogType>> log_batcher,
              std::shared_ptr<FileUploadStreamer<LogCollection>> log_file_upload_streamer = nullptr)
-          : CloudWatchService(log_publisher, log_batcher) {
+          : CloudWatchService(std::move(log_publisher), std::move(log_batcher)) {
 
-    this->file_upload_streamer_ = log_file_upload_streamer; // allow null, all this means is failures aren't written to file
+    this->file_upload_streamer_ = std::move(log_file_upload_streamer); // allow null, all this means is failures aren't written to file
   }
 
   /**
@@ -70,7 +71,7 @@ public:
   * @param milliseconds timestamp of the log event
   * @return the AWS SDK log object to  be send to CloudWatch
   */
-  virtual Aws::CloudWatchLogs::Model::InputLogEvent convertInputToBatched(
+  Aws::CloudWatchLogs::Model::InputLogEvent convertInputToBatched(
           const std::string &input,
           const std::chrono::milliseconds &milliseconds) override {
 
@@ -88,7 +89,7 @@ public:
   * @param input string input to be sent as a log
   * @return the AWS SDK log object to  be send to CloudWatch
   */
-  virtual Aws::CloudWatchLogs::Model::InputLogEvent convertInputToBatched(
+  Aws::CloudWatchLogs::Model::InputLogEvent convertInputToBatched(
           const std::string &input) override {
 
     Aws::CloudWatchLogs::Model::InputLogEvent log_event;
@@ -102,6 +103,6 @@ public:
 };
 
 
-}  // namespace CloudWatchlogs
-}  // namespace AWS
+}  // namespace CloudWatchLogs
+}  // namespace Aws
 

--- a/cloudwatch_logs_common/include/cloudwatch_logs_common/log_service.h
+++ b/cloudwatch_logs_common/include/cloudwatch_logs_common/log_service.h
@@ -37,10 +37,6 @@
 namespace Aws {
 namespace CloudWatchLogs {
 
-using namespace Aws::CloudWatchLogs;
-using namespace Aws::CloudWatchLogs::Utils;
-using namespace Aws::FileManagement;
-
 /**
  * Implementation to send logs to Cloudwatch. Note: though the batcher and publisher are required, the file streamer
  * is not. If the file streamer is not provided then log data is dropped if any failure is observed during the
@@ -58,7 +54,7 @@ public:
      */
   LogService(std::shared_ptr<Publisher<LogCollection>> log_publisher,
              std::shared_ptr<DataBatcher<LogType>> log_batcher,
-             std::shared_ptr<FileUploadStreamer<LogCollection>> log_file_upload_streamer = nullptr)
+             std::shared_ptr<Aws::FileManagement::FileUploadStreamer<LogCollection>> log_file_upload_streamer = nullptr)
           : CloudWatchService(std::move(log_publisher), std::move(log_batcher)) {
 
     this->file_upload_streamer_ = std::move(log_file_upload_streamer); // allow null, all this means is failures aren't written to file
@@ -102,7 +98,5 @@ public:
 
 };
 
-
 }  // namespace CloudWatchLogs
 }  // namespace Aws
-

--- a/cloudwatch_logs_common/include/cloudwatch_logs_common/log_service_factory.h
+++ b/cloudwatch_logs_common/include/cloudwatch_logs_common/log_service_factory.h
@@ -30,6 +30,13 @@ class LogServiceFactory
 {
 public:
   LogServiceFactory() = default;
+
+  /**
+   * Block copy constructor and assignment operator for Factory object.
+   */
+  LogServiceFactory(const LogServiceFactory &) = delete;
+  LogServiceFactory & operator=(const LogServiceFactory &) = delete;
+
   ~LogServiceFactory() = default;
 
   /**
@@ -43,18 +50,13 @@ public:
    *
    *  @return An instance of LogService
    */
+  // NOLINTNEXTLINE(google-default-arguments)
   virtual std::shared_ptr<LogService> CreateLogService(
     const std::string & log_group,
     const std::string & log_stream,
     const Aws::Client::ClientConfiguration & client_config,
     const Aws::SDKOptions & sdk_options,
     const CloudWatchOptions & cloudwatch_options = kDefaultCloudWatchOptions);
-private:
-  /**
-   * Block copy constructor and assignment operator for Factory object.
-   */
-  LogServiceFactory(const LogServiceFactory &) = delete;
-  LogServiceFactory & operator=(const LogServiceFactory &) = delete;
 };
 
 }  // namespace CloudWatchLogs

--- a/cloudwatch_logs_common/include/cloudwatch_logs_common/utils/cloudwatch_logs_facade.h
+++ b/cloudwatch_logs_common/include/cloudwatch_logs_common/utils/cloudwatch_logs_facade.h
@@ -43,14 +43,14 @@ public:
    *
    *  @param client_config The configuration for the cloudwatch client
    */
-  CloudWatchLogsFacade(const Aws::Client::ClientConfiguration & client_config);
+  explicit CloudWatchLogsFacade(const Aws::Client::ClientConfiguration & client_config);
 
   /**
    * @brief Creates a new CloudWatchLogsFacade with an existing client
    *
    * @param cw_client The client for interacting with cloudwatch
    */
-  CloudWatchLogsFacade(const std::shared_ptr<Aws::CloudWatchLogs::CloudWatchLogsClient> cw_client);
+  explicit CloudWatchLogsFacade(const std::shared_ptr<Aws::CloudWatchLogs::CloudWatchLogsClient>& cw_client);
 
   virtual ~CloudWatchLogsFacade() = default;
 

--- a/cloudwatch_logs_common/include/cloudwatch_logs_common/utils/cloudwatch_logs_facade.h
+++ b/cloudwatch_logs_common/include/cloudwatch_logs_common/utils/cloudwatch_logs_facade.h
@@ -43,14 +43,16 @@ public:
    *
    *  @param client_config The configuration for the cloudwatch client
    */
-  explicit CloudWatchLogsFacade(const Aws::Client::ClientConfiguration & client_config);
+  // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
+  CloudWatchLogsFacade(const Aws::Client::ClientConfiguration & client_config);
 
   /**
    * @brief Creates a new CloudWatchLogsFacade with an existing client
    *
    * @param cw_client The client for interacting with cloudwatch
    */
-  explicit CloudWatchLogsFacade(const std::shared_ptr<Aws::CloudWatchLogs::CloudWatchLogsClient>& cw_client);
+  // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
+  CloudWatchLogsFacade(const std::shared_ptr<Aws::CloudWatchLogs::CloudWatchLogsClient>& cw_client);
 
   virtual ~CloudWatchLogsFacade() = default;
 

--- a/cloudwatch_logs_common/include/cloudwatch_logs_common/utils/log_file_manager.h
+++ b/cloudwatch_logs_common/include/cloudwatch_logs_common/utils/log_file_manager.h
@@ -39,7 +39,7 @@ class LogFileManager :
    */
   LogFileManager()  = default;
 
-  LogFileManager(const Aws::FileManagement::FileManagerStrategyOptions &options)
+  explicit LogFileManager(const Aws::FileManagement::FileManagerStrategyOptions &options)
     : FileManager(options) {
   }
 
@@ -57,5 +57,5 @@ class LogFileManager :
 };
 
 }  // namespace Utils
-}  // namespace CloudwatchLogs
+}  // namespace CloudWatchLogs
 }  // namespace Aws

--- a/cloudwatch_logs_common/include/cloudwatch_logs_common/utils/log_file_manager.h
+++ b/cloudwatch_logs_common/include/cloudwatch_logs_common/utils/log_file_manager.h
@@ -39,12 +39,12 @@ class LogFileManager :
    */
   LogFileManager()  = default;
 
-  explicit LogFileManager(const Aws::FileManagement::FileManagerStrategyOptions &options)
+  // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
+  LogFileManager(const Aws::FileManagement::FileManagerStrategyOptions &options)
     : FileManager(options) {
   }
 
-  explicit LogFileManager(
-      const std::shared_ptr<FileManagerStrategy> &file_manager_strategy)
+  explicit LogFileManager(const std::shared_ptr<FileManagerStrategy> &file_manager_strategy)
       : FileManager(file_manager_strategy)
   {
   }

--- a/cloudwatch_logs_common/src/log_publisher.cpp
+++ b/cloudwatch_logs_common/src/log_publisher.cpp
@@ -30,6 +30,7 @@
 #include <list>
 #include <memory>
 #include <fstream>
+#include <utility>
 
 constexpr int kMaxRetries = 1; // todo this should probably be configurable, maybe part of the generic publisher interface
 
@@ -54,14 +55,12 @@ LogPublisher::LogPublisher(
   std::shared_ptr<Aws::CloudWatchLogs::Utils::CloudWatchLogsFacade> cloudwatch_facade)
   : run_state_(LOG_PUBLISHER_RUN_CREATE_GROUP)
 {
-  this->cloudwatch_facade_ = cloudwatch_facade;
+  this->cloudwatch_facade_ = std::move(cloudwatch_facade);
   this->log_group_ = log_group;
   this->log_stream_ = log_stream;
 }
 
-LogPublisher::~LogPublisher()
-{
-}
+LogPublisher::~LogPublisher() = default;
 
 bool LogPublisher::checkIfConnected(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors error) {
   if (CW_LOGS_NOT_CONNECTED == error) {

--- a/cloudwatch_logs_common/src/log_publisher.cpp
+++ b/cloudwatch_logs_common/src/log_publisher.cpp
@@ -32,9 +32,11 @@
 #include <fstream>
 #include <utility>
 
-constexpr int kMaxRetries = 1; // todo this should probably be configurable, maybe part of the generic publisher interface
 
-using namespace Aws::CloudWatchLogs;
+namespace Aws {
+namespace CloudWatchLogs {
+
+constexpr int kMaxRetries = 1; // todo this should probably be configurable, maybe part of the generic publisher interface
 
 LogPublisher::LogPublisher(
   const std::string & log_group,
@@ -319,3 +321,6 @@ bool LogPublisher::shutdown() {
   Aws::ShutdownAPI(this->options_);
   return is_shutdown;
 }
+
+}  // namespace CloudWatchLogs
+}  // namespace Aws

--- a/cloudwatch_logs_common/src/log_service_factory.cpp
+++ b/cloudwatch_logs_common/src/log_service_factory.cpp
@@ -31,10 +31,14 @@
 
 #include <cloudwatch_logs_common/definitions/definitions.h>
 
-using namespace Aws::CloudWatchLogs;
-using namespace Aws::CloudWatchLogs::Utils;
-using namespace Aws::FileManagement;
+using Aws::CloudWatchLogs::Utils::LogFileManager;
+using Aws::CloudWatchLogs::LogPublisher;
+using Aws::FileManagement::TaskObservedBlockingQueue;
 
+namespace Aws {
+namespace CloudWatchLogs {
+
+// NOLINTNEXTLINE(google-default-arguments)
 std::shared_ptr<LogService> LogServiceFactory::CreateLogService(
   const std::string & log_group,
   const std::string & log_stream,
@@ -49,9 +53,9 @@ std::shared_ptr<LogService> LogServiceFactory::CreateLogService(
   auto publisher = std::make_shared<LogPublisher>(log_group, log_stream, client_config);
 
   auto queue_monitor =
-      std::make_shared<Aws::DataFlow::QueueMonitor<TaskPtr<LogCollection>>>();
+      std::make_shared<Aws::DataFlow::QueueMonitor<Aws::FileManagement::TaskPtr<LogCollection>>>();
 
-  FileUploadStreamerOptions file_upload_options{
+  Aws::FileManagement::FileUploadStreamerOptions file_upload_options{
     cloudwatch_options.uploader_options.file_upload_batch_size,
     cloudwatch_options.uploader_options.file_max_queue_size
   };
@@ -89,3 +93,6 @@ std::shared_ptr<LogService> LogServiceFactory::CreateLogService(
 
   return log_service;  // allow user to start
 }
+
+}  // namespace CloudWatchLogs
+}  // namespace Aws

--- a/cloudwatch_logs_common/src/utils/cloudwatch_logs_facade.cpp
+++ b/cloudwatch_logs_common/src/utils/cloudwatch_logs_facade.cpp
@@ -30,7 +30,10 @@
 #include <cloudwatch_logs_common/utils/cloudwatch_logs_facade.h>
 #include <cloudwatch_logs_common/definitions/definitions.h>
 
-using namespace Aws::CloudWatchLogs::Utils;
+
+namespace Aws {
+namespace CloudWatchLogs {
+namespace Utils {
 
 constexpr uint16_t kMaxLogsPerRequest = 100;
 
@@ -200,7 +203,7 @@ Aws::CloudWatchLogs::ROSCloudWatchLogsErrors CloudWatchLogsFacade::CheckLogGroup
     auto & log_group_list = response.GetResult().GetLogGroups();
     next_token = response.GetResult().GetNextToken();
 
-    for (auto curr_log_group : log_group_list) {
+    for (const auto & curr_log_group : log_group_list) {
       if (curr_log_group.GetLogGroupName().c_str() == log_group) {
         AWS_LOGSTREAM_DEBUG(__func__, "Found Log Group named: " << log_group << ".");
         status = CW_LOGS_SUCCEEDED;
@@ -282,7 +285,7 @@ Aws::CloudWatchLogs::ROSCloudWatchLogsErrors CloudWatchLogsFacade::CheckLogStrea
     auto & log_stream_list = response.GetResult().GetLogStreams();
     next_token = response.GetResult().GetNextToken();
 
-    for (auto curr_log_stream : log_stream_list) {
+    for (const auto & curr_log_stream : log_stream_list) {
       if (curr_log_stream.GetLogStreamName().c_str() == log_stream) {
         AWS_LOGSTREAM_DEBUG(__func__, "Found Log Stream named: " << log_stream << " in Log Group :"
                                                                  << log_group << ".");
@@ -323,3 +326,7 @@ Aws::CloudWatchLogs::ROSCloudWatchLogsErrors CloudWatchLogsFacade::GetLogStreamT
 
   return status;
 }
+
+}  // namespace Utils
+}  // namespace CloudWatchLogs
+}  // namespace Aws

--- a/cloudwatch_logs_common/src/utils/cloudwatch_logs_facade.cpp
+++ b/cloudwatch_logs_common/src/utils/cloudwatch_logs_facade.cpp
@@ -39,7 +39,7 @@ CloudWatchLogsFacade::CloudWatchLogsFacade(const Aws::Client::ClientConfiguratio
   this->cw_client_ = std::make_shared<Aws::CloudWatchLogs::CloudWatchLogsClient>(client_config);
 }
 
-CloudWatchLogsFacade::CloudWatchLogsFacade(const std::shared_ptr<Aws::CloudWatchLogs::CloudWatchLogsClient> cw_client)
+CloudWatchLogsFacade::CloudWatchLogsFacade(const std::shared_ptr<Aws::CloudWatchLogs::CloudWatchLogsClient>& cw_client)
 {
   this->cw_client_ = cw_client;
 }
@@ -100,8 +100,8 @@ Aws::CloudWatchLogs::ROSCloudWatchLogsErrors CloudWatchLogsFacade::SendLogsToClo
     request.SetSequenceToken(next_token);
   }
 
-  for (auto it = logs.begin(); it != logs.end(); ++it) {
-    events.push_back(*it);
+  for (auto & log : logs) {
+    events.push_back(log);
     if (events.size() >= kMaxLogsPerRequest) {
       request.SetLogEvents(events);
       status = SendLogsRequest(request, next_token);
@@ -200,8 +200,7 @@ Aws::CloudWatchLogs::ROSCloudWatchLogsErrors CloudWatchLogsFacade::CheckLogGroup
     auto & log_group_list = response.GetResult().GetLogGroups();
     next_token = response.GetResult().GetNextToken();
 
-    for (auto it = log_group_list.begin(); it != log_group_list.end(); ++it) {
-      Aws::CloudWatchLogs::Model::LogGroup curr_log_group = *it;
+    for (auto curr_log_group : log_group_list) {
       if (curr_log_group.GetLogGroupName().c_str() == log_group) {
         AWS_LOGSTREAM_DEBUG(__func__, "Found Log Group named: " << log_group << ".");
         status = CW_LOGS_SUCCEEDED;
@@ -283,8 +282,7 @@ Aws::CloudWatchLogs::ROSCloudWatchLogsErrors CloudWatchLogsFacade::CheckLogStrea
     auto & log_stream_list = response.GetResult().GetLogStreams();
     next_token = response.GetResult().GetNextToken();
 
-    for (auto it = log_stream_list.begin(); it != log_stream_list.end(); ++it) {
-      Aws::CloudWatchLogs::Model::LogStream curr_log_stream = *it;
+    for (auto curr_log_stream : log_stream_list) {
       if (curr_log_stream.GetLogStreamName().c_str() == log_stream) {
         AWS_LOGSTREAM_DEBUG(__func__, "Found Log Stream named: " << log_stream << " in Log Group :"
                                                                  << log_group << ".");

--- a/cloudwatch_logs_common/src/utils/log_file_manager.cpp
+++ b/cloudwatch_logs_common/src/utils/log_file_manager.cpp
@@ -76,5 +76,5 @@ void LogFileManager::write(const LogCollection & data) {
 }
 
 }  // namespace Utils
-}  // namespace CloudwatchLogs
+}  // namespace CloudWatchLogs
 }  // namespace Aws

--- a/cloudwatch_logs_common/test/cloudwatch_facade_test.cpp
+++ b/cloudwatch_logs_common/test/cloudwatch_facade_test.cpp
@@ -35,7 +35,7 @@ protected:
   Aws::SDKOptions options_;
   std::shared_ptr<CloudWatchLogsFacade> facade_;
   std::shared_ptr<CloudWatchLogsClientMock> mock_client;
-  CloudWatchLogsClientMock* mock_client_p;
+  CloudWatchLogsClientMock* mock_client_p{};
 
   void SetUp() override
   {
@@ -127,7 +127,7 @@ TEST_F(TestCloudWatchFacade, TestCWLogsFacade_CreateLogGroup_SuccessResponse)
 
 TEST_F(TestCloudWatchFacade, TestCWLogsFacade_CreateLogGroup_FailedResponse)
 {
-    Aws::CloudWatchLogs::Model::CreateLogGroupOutcome* failedOutcome =
+    auto* failedOutcome =
         new Aws::CloudWatchLogs::Model::CreateLogGroupOutcome();
 
     EXPECT_CALL(*mock_client_p, CreateLogGroup(testing::_))
@@ -142,7 +142,7 @@ TEST_F(TestCloudWatchFacade, TestCWLogsFacade_CreateLogGroup_AlreadyExists)
     Aws::Client::AWSError<Aws::CloudWatchLogs::CloudWatchLogsErrors> error
     (Aws::CloudWatchLogs::CloudWatchLogsErrors::RESOURCE_ALREADY_EXISTS, false);
 
-    Aws::CloudWatchLogs::Model::CreateLogGroupOutcome* failedOutcome =
+    auto* failedOutcome =
         new Aws::CloudWatchLogs::Model::CreateLogGroupOutcome(error);
 
     EXPECT_CALL(*mock_client_p, CreateLogGroup(testing::_))
@@ -213,7 +213,7 @@ TEST_F(TestCloudWatchFacade, TestCWLogsFacade_CreateLogStream_SuccessResponse)
 
 TEST_F(TestCloudWatchFacade, TestCWLogsFacade_CreateLogStream_FailedResponse)
 {
-    Aws::CloudWatchLogs::Model::CreateLogStreamOutcome* failedOutcome =
+    auto* failedOutcome =
         new Aws::CloudWatchLogs::Model::CreateLogStreamOutcome();
 
     EXPECT_CALL(*mock_client_p, CreateLogStream(testing::_))
@@ -228,7 +228,7 @@ TEST_F(TestCloudWatchFacade, TestCWLogsFacade_CreateLogStream_AlreadyExists)
     Aws::Client::AWSError<Aws::CloudWatchLogs::CloudWatchLogsErrors> error
     (Aws::CloudWatchLogs::CloudWatchLogsErrors::RESOURCE_ALREADY_EXISTS, false);
 
-    Aws::CloudWatchLogs::Model::CreateLogStreamOutcome* failedOutcome =
+    auto* failedOutcome =
         new Aws::CloudWatchLogs::Model::CreateLogStreamOutcome(error);
 
     EXPECT_CALL(*mock_client_p, CreateLogStream(testing::_))
@@ -264,7 +264,7 @@ TEST_F(TestCloudWatchFacade, TestCWLogsFacade_CheckLogStreamExists_LogStreamExis
     EXPECT_CALL(*mock_client_p, DescribeLogStreams(testing::_))
         .WillOnce(testing::Return(existsOutcome));
 
-    Aws::CloudWatchLogs::Model::LogStream * log_stream_object = new Aws::CloudWatchLogs::Model::LogStream();
+    auto * log_stream_object = new Aws::CloudWatchLogs::Model::LogStream();
     EXPECT_EQ(Aws::CloudWatchLogs::ROSCloudWatchLogsErrors::CW_LOGS_SUCCEEDED,
         facade_->CheckLogStreamExists(LOG_GROUP_NAME1, LOG_STREAM_NAME1, log_stream_object));
 }

--- a/cloudwatch_logs_common/test/log_publisher_test.cpp
+++ b/cloudwatch_logs_common/test/log_publisher_test.cpp
@@ -29,17 +29,17 @@ constexpr int WAIT_TIME =
 class MockCloudWatchFacade : public Aws::CloudWatchLogs::Utils::CloudWatchLogsFacade
 {
 public:
-  uint32_t send_logs_call_count;
+  uint32_t send_logs_call_count{};
   std::string last_log_group;
   std::string last_log_stream;
   std::list<Aws::CloudWatchLogs::Model::InputLogEvent> last_logs;
   Aws::String next_token;
-  bool fail_cw_log_group;
-  bool fail_cw_log_stream;
-  bool fail_cw_create_log_group;
-  bool fail_cw_create_log_stream;
-  bool fail_cw_init_token;
-  bool fail_cw_send_logs;
+  bool fail_cw_log_group{};
+  bool fail_cw_log_stream{};
+  bool fail_cw_create_log_group{};
+  bool fail_cw_create_log_stream{};
+  bool fail_cw_init_token{};
+  bool fail_cw_send_logs{};
   void Reset()
   {
     this->last_log_group = "";

--- a/cloudwatch_logs_common/test/pipeline_test.cpp
+++ b/cloudwatch_logs_common/test/pipeline_test.cpp
@@ -38,6 +38,7 @@
 
 using namespace Aws::CloudWatchLogs;
 using namespace Aws::CloudWatchLogs::Utils;
+using namespace Aws::FileManagement;
 using namespace std::chrono_literals;
 
 /**

--- a/cloudwatch_logs_common/test/pipeline_test.cpp
+++ b/cloudwatch_logs_common/test/pipeline_test.cpp
@@ -51,7 +51,7 @@ public:
     force_invalid_data_failure = false;
     last_upload_status = Aws::DataFlow::UploadStatus::UNKNOWN;
   };
-  virtual ~TestPublisher() = default;
+  ~TestPublisher() override = default;
 
   bool start() override {
     return Publisher::start();
@@ -79,7 +79,7 @@ public:
 protected:
 
   // override so we can notify when internal state changes, as attemptPublish sets state
-  virtual Aws::DataFlow::UploadStatus attemptPublish(std::list<Aws::CloudWatchLogs::Model::InputLogEvent> &data) override {
+  Aws::DataFlow::UploadStatus attemptPublish(std::list<Aws::CloudWatchLogs::Model::InputLogEvent> &data) override {
     last_upload_status = Publisher::attemptPublish(data);
     {
       this->notify();
@@ -122,15 +122,15 @@ public:
       this->notify();
     };
 
-    FileObject<LogCollection> readBatch(size_t batch_size) {
+    FileObject<LogCollection> readBatch(size_t batch_size) override {
       // do nothing
       FileObject<LogCollection> testFile;
       testFile.batch_size = batch_size;
       return testFile;
     }
 
-    std::atomic<int> written_count;
-    std::atomic<size_t> last_data_size;
+    std::atomic<int> written_count{};
+    std::atomic<size_t> last_data_size{};
     std::condition_variable cv;
     mutable std::mutex mtx;
 };
@@ -399,7 +399,7 @@ TEST_F(PipelineTest, TestPublisherIntermittant) {
       EXPECT_EQ(expected_success, test_publisher->getPublishSuccesses());
       EXPECT_EQ(i, test_publisher->getPublishAttempts());
 
-      float expected_percentage = (float) expected_success / (float) i * 100.0f;
+      float expected_percentage = static_cast<float>(expected_success) / static_cast<float>(i) * 100.0f;
       EXPECT_FLOAT_EQ(expected_percentage, test_publisher->getPublishSuccessPercentage());
 
       fileManager->wait_for_millis(std::chrono::milliseconds(100));

--- a/cloudwatch_metrics_common/include/cloudwatch_metrics_common/cloudwatch_options.h
+++ b/cloudwatch_metrics_common/include/cloudwatch_metrics_common/cloudwatch_options.h
@@ -28,7 +28,7 @@ struct CloudWatchOptions {
   /**
    * All options for the FileUpload system
    */
-  Aws::DataFlow::UploaderOptions uploader_options;
+  Aws::DataFlow::UploaderOptions uploader_options{};
   /**
    * All options for the FileManager system
    */

--- a/cloudwatch_metrics_common/include/cloudwatch_metrics_common/metric_batcher.h
+++ b/cloudwatch_metrics_common/include/cloudwatch_metrics_common/metric_batcher.h
@@ -47,7 +47,11 @@ public:
      *  @param size of the batched data that will trigger a publish
      */
     explicit MetricBatcher(size_t max_allowable_batch_size = DataBatcher::kDefaultMaxBatchSize,
-                        size_t publish_trigger_size = DataBatcher::kDefaultTriggerSize);
+                           size_t publish_trigger_size = DataBatcher::kDefaultTriggerSize);
+
+    MetricBatcher(const MetricBatcher & other) = delete;
+
+    MetricBatcher & operator=(const MetricBatcher & other) = delete;
 
     /**
      *  @brief Tears down a MetricBatcher object

--- a/cloudwatch_metrics_common/include/cloudwatch_metrics_common/metric_batcher.h
+++ b/cloudwatch_metrics_common/include/cloudwatch_metrics_common/metric_batcher.h
@@ -52,7 +52,7 @@ public:
     /**
      *  @brief Tears down a MetricBatcher object
      */
-    virtual ~MetricBatcher();
+    ~MetricBatcher() override;
 
     /**
      * Queue the batched data to be given to the publisher and sent to CloudWatch. Attempts to write to disk (through
@@ -60,16 +60,16 @@ public:
      *
      * @return true if the batched data could be queued, false otherwise
      */
-    virtual bool publishBatchedData() override;
+    bool publishBatchedData() override;
     /**
      * Override default behavior to attempt to write to file to disk when emptying the collection.
      */
-    virtual void emptyCollection() override;
+    void emptyCollection() override;
     /**
      * Start this service
      * @return
      */
-    virtual bool start() override;
+    bool start() override;
 
     /**
      * Set the log file manager, used for task publishing failures (write to disk if unable to send to CloudWatch).

--- a/cloudwatch_metrics_common/include/cloudwatch_metrics_common/metric_publisher.hpp
+++ b/cloudwatch_metrics_common/include/cloudwatch_metrics_common/metric_publisher.hpp
@@ -43,20 +43,20 @@ public:
 
   MetricPublisher(const std::string & metrics_namespace, const Aws::Client::ClientConfiguration & client_config);
   MetricPublisher(const std::string & metrics_namespace,
-    const std::shared_ptr<Aws::CloudWatchMetrics::Utils::CloudWatchMetricsFacade> cloudwatch_metrics_facade);
+    const std::shared_ptr<Aws::CloudWatchMetrics::Utils::CloudWatchMetricsFacade>& cloudwatch_metrics_facade);
 
   /**
    *  @brief Tears down the MetricPublisher object
    */
-  virtual ~MetricPublisher() = default;
+  ~MetricPublisher() override = default;
 
-  virtual bool shutdown() override;
+  bool shutdown() override;
   /**
    * Create the cloudwatch facade
    *
    * @return
    */
-  virtual bool start() override;
+  bool start() override;
   /**
    * Attempt to publish the input data.
    *

--- a/cloudwatch_metrics_common/include/cloudwatch_metrics_common/metric_publisher.hpp
+++ b/cloudwatch_metrics_common/include/cloudwatch_metrics_common/metric_publisher.hpp
@@ -40,10 +40,8 @@ class MetricPublisher : public Publisher<MetricDatumCollection>
 {
 public:
 
-
   MetricPublisher(const std::string & metrics_namespace, const Aws::Client::ClientConfiguration & client_config);
-  MetricPublisher(const std::string & metrics_namespace,
-    const std::shared_ptr<Aws::CloudWatchMetrics::Utils::CloudWatchMetricsFacade>& cloudwatch_metrics_facade);
+  MetricPublisher(const std::string & metrics_namespace, std::shared_ptr<Utils::CloudWatchMetricsFacade> cloudwatch_metrics_facade);
 
   /**
    *  @brief Tears down the MetricPublisher object

--- a/cloudwatch_metrics_common/include/cloudwatch_metrics_common/metric_service.hpp
+++ b/cloudwatch_metrics_common/include/cloudwatch_metrics_common/metric_service.hpp
@@ -33,6 +33,7 @@
 
 #include <chrono>
 #include <stdexcept>
+#include <utility>
 
 namespace Aws {
 namespace CloudWatchMetrics {
@@ -62,9 +63,9 @@ public:
             std::shared_ptr<DataBatcher<MetricDatum>> batcher,
             std::shared_ptr<FileUploadStreamer<MetricDatumCollection>> file_upload_streamer = nullptr
             )
-            : CloudWatchService(publisher, batcher) {
+            : CloudWatchService(std::move(publisher), std::move(batcher)) {
 
-      this->file_upload_streamer_ = file_upload_streamer;
+      this->file_upload_streamer_ = std::move(file_upload_streamer);
     }
 
     /**
@@ -74,11 +75,11 @@ public:
      * @param milliseconds timestamp to use for metric
      * @return MetricDatum to publish
      */
-    virtual MetricDatum convertInputToBatched(
+    MetricDatum convertInputToBatched(
             const MetricObject &input,
             const std::chrono::milliseconds &milliseconds) override {
 
-      return metricObjectToDatum(input, (int64_t) milliseconds.count());
+      return metricObjectToDatum(input, static_cast<int64_t>(milliseconds.count()));
     }
 
     /**
@@ -87,7 +88,7 @@ public:
      * @param input MetricObject to convert
      * @return MetricDatum to publish
      */
-    virtual MetricDatum convertInputToBatched(
+    MetricDatum convertInputToBatched(
             const MetricObject &input) override {
 
       return metricObjectToDatum(input, input.timestamp);

--- a/cloudwatch_metrics_common/include/cloudwatch_metrics_common/metric_service.hpp
+++ b/cloudwatch_metrics_common/include/cloudwatch_metrics_common/metric_service.hpp
@@ -38,16 +38,12 @@
 namespace Aws {
 namespace CloudWatchMetrics {
 
-using namespace Aws::CloudWatchMetrics;
-using namespace Aws::CloudWatchMetrics::Utils;
-using namespace Aws::FileManagement;
-
 /**
  * Implementation to send metrics to CloudWatch. Note: though the batcher and publisher are required, the file streamer
  * is not. If the file streamer is not provided then metric data is dropped if any failure is observed during the
  * attempt to publish.
  */
-class MetricService : public Aws::CloudWatch::CloudWatchService<MetricObject, MetricDatum>
+class MetricService : public Aws::CloudWatch::CloudWatchService<Utils::MetricObject, MetricDatum>
 {
 public:
 
@@ -61,8 +57,7 @@ public:
     MetricService(
             std::shared_ptr<Publisher<MetricDatumCollection>> publisher,
             std::shared_ptr<DataBatcher<MetricDatum>> batcher,
-            std::shared_ptr<FileUploadStreamer<MetricDatumCollection>> file_upload_streamer = nullptr
-            )
+            std::shared_ptr<Aws::FileManagement::FileUploadStreamer<MetricDatumCollection>> file_upload_streamer = nullptr)
             : CloudWatchService(std::move(publisher), std::move(batcher)) {
 
       this->file_upload_streamer_ = std::move(file_upload_streamer);
@@ -76,7 +71,7 @@ public:
      * @return MetricDatum to publish
      */
     MetricDatum convertInputToBatched(
-            const MetricObject &input,
+            const Utils::MetricObject &input,
             const std::chrono::milliseconds &milliseconds) override {
 
       return metricObjectToDatum(input, static_cast<int64_t>(milliseconds.count()));
@@ -88,8 +83,7 @@ public:
      * @param input MetricObject to convert
      * @return MetricDatum to publish
      */
-    MetricDatum convertInputToBatched(
-            const MetricObject &input) override {
+    MetricDatum convertInputToBatched(const Utils::MetricObject &input) override {
 
       return metricObjectToDatum(input, input.timestamp);
     }

--- a/cloudwatch_metrics_common/include/cloudwatch_metrics_common/metric_service_factory.hpp
+++ b/cloudwatch_metrics_common/include/cloudwatch_metrics_common/metric_service_factory.hpp
@@ -26,6 +26,13 @@ class MetricServiceFactory
 {
 public:
   MetricServiceFactory() = default;
+
+  /**
+   * Block copy constructor and assignment operator for Factory object.
+   */
+  MetricServiceFactory(const MetricServiceFactory &) = delete;
+  MetricServiceFactory & operator=(const MetricServiceFactory &) = delete;
+
   ~MetricServiceFactory() = default;
 
   /**
@@ -37,18 +44,12 @@ public:
    * @param cloudwatch_options
    * @return
    */
+  // NOLINTNEXTLINE(google-default-arguments)
   virtual std::shared_ptr<MetricService> createMetricService(
           const std::string & metrics_namespace,
           const Aws::Client::ClientConfiguration & client_config,
           const Aws::SDKOptions & sdk_options,
           const CloudWatchOptions & cloudwatch_options = kDefaultCloudWatchOptions);
-
-private:
-  /**
-   * Block copy constructor and assignment operator for Factory object.
-   */
-  MetricServiceFactory(const MetricServiceFactory &) = delete;
-  MetricServiceFactory & operator=(const MetricServiceFactory &) = delete;
 };
 
 }  // namespace CloudWatchMetrics

--- a/cloudwatch_metrics_common/include/cloudwatch_metrics_common/utils/cloudwatch_metrics_facade.hpp
+++ b/cloudwatch_metrics_common/include/cloudwatch_metrics_common/utils/cloudwatch_metrics_facade.hpp
@@ -52,12 +52,12 @@ public:
    *  @brief Creates a new CloudWatchMetricsFacade
    *  @param client_config The configuration for the cloudwatch client
    */
-  CloudWatchMetricsFacade(const Aws::Client::ClientConfiguration & client_config);
+  explicit CloudWatchMetricsFacade(const Aws::Client::ClientConfiguration & client_config);
   /**
    * @brief Creates a new CloudWatchMetricsFacade with an existing client
    * @param cw_client The client for interacting with cloudwatch
    */
-  CloudWatchMetricsFacade(const std::shared_ptr<Aws::CloudWatch::CloudWatchClient> cw_client);
+  explicit CloudWatchMetricsFacade(const std::shared_ptr<Aws::CloudWatch::CloudWatchClient>& cw_client);
   virtual ~CloudWatchMetricsFacade() = default;
 
   /**

--- a/cloudwatch_metrics_common/include/cloudwatch_metrics_common/utils/cloudwatch_metrics_facade.hpp
+++ b/cloudwatch_metrics_common/include/cloudwatch_metrics_common/utils/cloudwatch_metrics_facade.hpp
@@ -52,12 +52,15 @@ public:
    *  @brief Creates a new CloudWatchMetricsFacade
    *  @param client_config The configuration for the cloudwatch client
    */
-  explicit CloudWatchMetricsFacade(const Aws::Client::ClientConfiguration & client_config);
+  // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
+  CloudWatchMetricsFacade(const Aws::Client::ClientConfiguration & client_config);
   /**
    * @brief Creates a new CloudWatchMetricsFacade with an existing client
    * @param cw_client The client for interacting with cloudwatch
    */
-  explicit CloudWatchMetricsFacade(const std::shared_ptr<Aws::CloudWatch::CloudWatchClient>& cw_client);
+  // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
+  CloudWatchMetricsFacade(const std::shared_ptr<Aws::CloudWatch::CloudWatchClient>& cw_client);
+
   virtual ~CloudWatchMetricsFacade() = default;
 
   /**

--- a/cloudwatch_metrics_common/include/cloudwatch_metrics_common/utils/metric_file_manager.hpp
+++ b/cloudwatch_metrics_common/include/cloudwatch_metrics_common/utils/metric_file_manager.hpp
@@ -40,7 +40,7 @@ public:
    */
   MetricFileManager() = default;
 
-  MetricFileManager(const Aws::FileManagement::FileManagerStrategyOptions &options)
+  explicit MetricFileManager(const Aws::FileManagement::FileManagerStrategyOptions &options)
     : FileManager(options) {
   }
 
@@ -65,5 +65,5 @@ public:
 };
 
 }  // namespace Utils
-}  // namespace CloudwatchMetrics
+}  // namespace CloudWatchMetrics
 }  // namespace Aws

--- a/cloudwatch_metrics_common/include/cloudwatch_metrics_common/utils/metric_file_manager.hpp
+++ b/cloudwatch_metrics_common/include/cloudwatch_metrics_common/utils/metric_file_manager.hpp
@@ -40,7 +40,8 @@ public:
    */
   MetricFileManager() = default;
 
-  explicit MetricFileManager(const Aws::FileManagement::FileManagerStrategyOptions &options)
+  // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
+  MetricFileManager(const Aws::FileManagement::FileManagerStrategyOptions &options)
     : FileManager(options) {
   }
 

--- a/cloudwatch_metrics_common/include/cloudwatch_metrics_common/utils/metric_object.h
+++ b/cloudwatch_metrics_common/include/cloudwatch_metrics_common/utils/metric_object.h
@@ -102,7 +102,7 @@ struct MetricObject {
   std::string metric_name;
   std::string unit;
   int64_t timestamp;
-  double value; // mutually exclusive with statistic_values
+  double value{}; // mutually exclusive with statistic_values
   std::map<StatisticValuesType, double> statistic_values; // mutually exclusive with value
   std::map<std::string, std::string> dimensions;
   int storage_resolution;
@@ -138,7 +138,7 @@ static MetricDatum metricObjectToDatum(const MetricObject &metrics, const int64_
         stats.SetSampleCount(keyval.second);
       }
     }
-    datum.SetStatisticValues(std::move(stats));
+    datum.SetStatisticValues(stats);
   }
 
   auto mapped_unit = units_mapper.find(metrics.unit);
@@ -149,10 +149,10 @@ static MetricDatum metricObjectToDatum(const MetricObject &metrics, const int64_
     datum.SetUnit(Aws::CloudWatch::Model::StandardUnitMapper::GetStandardUnitForName(unit_name));
   }
 
-  for (auto it = metrics.dimensions.begin(); it != metrics.dimensions.end(); ++it) {
+  for (const auto & it : metrics.dimensions) {
     Aws::CloudWatch::Model::Dimension dimension;
-    Aws::String name(it->first.c_str());
-    Aws::String d_value(it->second.c_str());
+    Aws::String name(it.first.c_str());
+    Aws::String d_value(it.second.c_str());
     dimension.WithName(name).WithValue(d_value);
     datum.AddDimensions(dimension);
   }

--- a/cloudwatch_metrics_common/src/metric_publisher.cpp
+++ b/cloudwatch_metrics_common/src/metric_publisher.cpp
@@ -36,7 +36,7 @@ MetricPublisher::MetricPublisher(
 }
 
 MetricPublisher::MetricPublisher(const std::string & metrics_namespace,
-                const std::shared_ptr<Aws::CloudWatchMetrics::Utils::CloudWatchMetricsFacade> cloudwatch_metrics_facade)
+                const std::shared_ptr<Aws::CloudWatchMetrics::Utils::CloudWatchMetricsFacade>& cloudwatch_metrics_facade)
 {
   this->metrics_namespace_ = metrics_namespace;
   this->cloudwatch_metrics_facade_ = cloudwatch_metrics_facade;

--- a/cloudwatch_metrics_common/src/metric_publisher.cpp
+++ b/cloudwatch_metrics_common/src/metric_publisher.cpp
@@ -24,8 +24,12 @@
 
 #include <memory>
 
-using namespace Aws::CloudWatchMetrics;
-using namespace Aws::CloudWatchMetrics::Utils;
+using Aws::CloudWatchMetrics::Utils::CloudWatchMetricsFacade;
+using Aws::CloudWatchMetrics::Utils::CloudWatchMetricsStatus;
+
+
+namespace Aws {
+namespace CloudWatchMetrics {
 
 MetricPublisher::MetricPublisher(
   const std::string & metrics_namespace,
@@ -36,10 +40,10 @@ MetricPublisher::MetricPublisher(
 }
 
 MetricPublisher::MetricPublisher(const std::string & metrics_namespace,
-                const std::shared_ptr<Aws::CloudWatchMetrics::Utils::CloudWatchMetricsFacade>& cloudwatch_metrics_facade)
+                                 std::shared_ptr<Utils::CloudWatchMetricsFacade> cloudwatch_metrics_facade)
 {
   this->metrics_namespace_ = metrics_namespace;
-  this->cloudwatch_metrics_facade_ = cloudwatch_metrics_facade;
+  this->cloudwatch_metrics_facade_ = std::move(cloudwatch_metrics_facade);
 }
 
 bool MetricPublisher::start() {
@@ -71,3 +75,6 @@ Aws::DataFlow::UploadStatus MetricPublisher::publishData(MetricDatumCollection &
       return Aws::DataFlow::UploadStatus::FAIL;
   }
 }
+
+}  // namespace CloudWatchMetrics
+}  // namespace Aws

--- a/cloudwatch_metrics_common/src/metric_service_factory.cpp
+++ b/cloudwatch_metrics_common/src/metric_service_factory.cpp
@@ -29,9 +29,16 @@
 
 #include <cloudwatch_metrics_common/definitions/definitions.h>
 
-using namespace Aws::CloudWatchMetrics;
+using Aws::CloudWatchMetrics::Utils::MetricFileManager;
+using Aws::CloudWatchMetrics::MetricPublisher;
+using Aws::FileManagement::TaskObservedBlockingQueue;
 
-std::shared_ptr<MetricService> MetricServiceFactory:: createMetricService(
+
+namespace Aws {
+namespace CloudWatchMetrics {
+
+// NOLINTNEXTLINE(google-default-arguments)
+std::shared_ptr<MetricService> MetricServiceFactory::createMetricService(
         const std::string & metrics_namespace,
         const Aws::Client::ClientConfiguration & client_config,
         const Aws::SDKOptions & sdk_options,
@@ -44,9 +51,9 @@ std::shared_ptr<MetricService> MetricServiceFactory:: createMetricService(
   auto metric_publisher = std::make_shared<MetricPublisher>(metrics_namespace, client_config);
 
   auto queue_monitor =
-          std::make_shared<Aws::DataFlow::QueueMonitor<TaskPtr<MetricDatumCollection>>>();
+          std::make_shared<Aws::DataFlow::QueueMonitor<Aws::FileManagement::TaskPtr<MetricDatumCollection>>>();
 
-  FileUploadStreamerOptions file_upload_options{
+  Aws::FileManagement::FileUploadStreamerOptions file_upload_options{
     cloudwatch_options.uploader_options.file_upload_batch_size,
     cloudwatch_options.uploader_options.file_max_queue_size
   };
@@ -84,3 +91,6 @@ std::shared_ptr<MetricService> MetricServiceFactory:: createMetricService(
 
   return metric_service;
 }
+
+}  // namespace CloudWatchMetrics
+}  // namespace Aws

--- a/cloudwatch_metrics_common/src/utils/cloudwatch_metrics_facade.cpp
+++ b/cloudwatch_metrics_common/src/utils/cloudwatch_metrics_facade.cpp
@@ -36,7 +36,7 @@ CloudWatchMetricsFacade::CloudWatchMetricsFacade(const Aws::Client::ClientConfig
   this->cw_client_ = std::make_shared<Aws::CloudWatch::CloudWatchClient>(client_config);
 }
 
-CloudWatchMetricsFacade::CloudWatchMetricsFacade(const std::shared_ptr<Aws::CloudWatch::CloudWatchClient> cw_client)
+CloudWatchMetricsFacade::CloudWatchMetricsFacade(const std::shared_ptr<Aws::CloudWatch::CloudWatchClient>& cw_client)
 {
   this->cw_client_ = cw_client;
 }
@@ -85,8 +85,8 @@ CloudWatchMetricsStatus CloudWatchMetricsFacade::SendMetricsToCloudWatch(
   request.SetNamespace(metric_namespace.c_str());
 
   // Note: this fails an entire set of metrics, even if some are sent back successfully
-  for (auto it = metrics.begin(); it != metrics.end(); ++it) {
-    datums.push_back(*it);
+  for (auto & metric : metrics) {
+    datums.push_back(metric);
     if (datums.size() >= MAX_METRIC_DATUMS_PER_REQUEST) {
 
       request.SetMetricData(datums);

--- a/cloudwatch_metrics_common/src/utils/cloudwatch_metrics_facade.cpp
+++ b/cloudwatch_metrics_common/src/utils/cloudwatch_metrics_facade.cpp
@@ -26,7 +26,9 @@
 
 #include <string>
 
-using namespace Aws::CloudWatchMetrics::Utils;
+namespace Aws {
+namespace CloudWatchMetrics {
+namespace Utils {
 
 // https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutMetricData.html
 #define MAX_METRIC_DATUMS_PER_REQUEST 20
@@ -107,3 +109,7 @@ CloudWatchMetricsStatus CloudWatchMetricsFacade::SendMetricsToCloudWatch(
 
   return status;
 }
+
+}  // namespace Utils
+}  // namespace CloudWatchMetrics
+}  // namespace Aws

--- a/cloudwatch_metrics_common/src/utils/metric_file_manager.cpp
+++ b/cloudwatch_metrics_common/src/utils/metric_file_manager.cpp
@@ -84,5 +84,5 @@ void MetricFileManager::write(const MetricDatumCollection &data) {
 }
 
 }  // namespace Utils
-}  // namespace Cloudwatchmetrics
+}  // namespace CloudWatchMetrics
 }  // namespace Aws

--- a/cloudwatch_metrics_common/src/utils/metric_serialization.cpp
+++ b/cloudwatch_metrics_common/src/utils/metric_serialization.cpp
@@ -55,7 +55,7 @@ MetricDatum deserializeMetricDatum(const Aws::String &basic_string) {
     throw std::invalid_argument("Failed to parse metric JSON string");
   }
   auto view = json_value.View();
-  for (const auto property : required_properties) {
+  for (const auto& property : required_properties) {
     if (!view.KeyExists(property)) {
       std::string property_name(property.c_str());
       throw std::invalid_argument("Could not find required property " + property_name + " in JSON string");
@@ -99,7 +99,7 @@ MetricDatum deserializeMetricDatum(const Aws::String &basic_string) {
 Aws::String serializeMetricDatum(const MetricDatum &datum) {
   Aws::Utils::Json::JsonValue json_value;
 
-  const Aws::Vector<Aws::CloudWatch::Model::Dimension> dimensions = datum.GetDimensions();
+  const Aws::Vector<Aws::CloudWatch::Model::Dimension>& dimensions = datum.GetDimensions();
   Aws::Utils::Array<JsonValue> dimensions_array = Aws::Utils::Array<JsonValue>(dimensions.size());
   for (size_t i = 0; i < dimensions.size(); ++i) {
     JsonValue dimension_json;
@@ -108,7 +108,7 @@ Aws::String serializeMetricDatum(const MetricDatum &datum) {
         .WithString(kDimensionsValueKey, dimensions[i].GetValue());
   }
 
-  const Aws::Vector<double> values = datum.GetValues();
+  const Aws::Vector<double>& values = datum.GetValues();
   Aws::Utils::Array<JsonValue> values_array = Aws::Utils::Array<JsonValue>(values.size());
   for (size_t i = 0; i < values.size(); ++i) {
     JsonValue val;
@@ -126,5 +126,5 @@ Aws::String serializeMetricDatum(const MetricDatum &datum) {
 }
 
 }  // namespace Utils
-}  // namespace CloudwatchMetrics
+}  // namespace CloudWatchMetrics
 }  // namespace Aws

--- a/cloudwatch_metrics_common/test/metric_pipeline_test.cpp
+++ b/cloudwatch_metrics_common/test/metric_pipeline_test.cpp
@@ -41,6 +41,7 @@
 
 using namespace Aws::CloudWatchMetrics;
 using namespace Aws::CloudWatchMetrics::Utils;
+using namespace Aws::FileManagement;
 using namespace std::chrono_literals;
 
 /**

--- a/cloudwatch_metrics_common/test/metric_pipeline_test.cpp
+++ b/cloudwatch_metrics_common/test/metric_pipeline_test.cpp
@@ -55,7 +55,7 @@ public:
     last_upload_status = Aws::DataFlow::UploadStatus::UNKNOWN;
   };
 
-  virtual ~TestPublisher() = default    ;
+  ~TestPublisher() override = default    ;
 
   bool start() override {
     return Publisher::start();
@@ -126,15 +126,15 @@ public:
       this->notify();
     };
 
-    FileObject<MetricDatumCollection> readBatch(size_t batch_size) {
+    FileObject<MetricDatumCollection> readBatch(size_t batch_size) override {
       // do nothing
       FileObject<MetricDatumCollection> testFile;
       testFile.batch_size = batch_size;
       return testFile;
     }
 
-    std::atomic<int> written_count;
-    std::atomic<size_t> last_data_size;
+    std::atomic<int> written_count{};
+    std::atomic<size_t> last_data_size{};
     std::condition_variable cv; // todo think about adding this into the interface
     mutable std::mutex mtx; // todo think about adding this  into  the interface
 };
@@ -463,7 +463,7 @@ TEST_F(PipelineTest, TestPublisherIntermittant) {
               Aws::DataFlow::UploadStatus::FAIL: Aws::DataFlow::UploadStatus::SUCCESS,
               test_publisher->getLastUploadStatus());
 
-    float expected_percentage = (float) expected_success / (float) i * 100.0f;
+    float expected_percentage = static_cast<float>(expected_success) / static_cast<float>(i) * 100.0f;
     EXPECT_FLOAT_EQ(expected_percentage, test_publisher->getPublishSuccessPercentage());
 
     fileManager->wait_for_millis(std::chrono::milliseconds(100));

--- a/cloudwatch_metrics_common/test/metric_publisher_test.cpp
+++ b/cloudwatch_metrics_common/test/metric_publisher_test.cpp
@@ -32,7 +32,7 @@ class MockCloudWatchFacade : public Utils::CloudWatchMetricsFacade
 {
 public:
   Utils::CloudWatchMetricsStatus send_metrics_ret_val;
-  uint32_t send_metrics_call_count;
+  uint32_t send_metrics_call_count{};
   std::string last_metric_namespace;
   MetricDatumCollection last_metrics;
 

--- a/cloudwatch_metrics_common/test/metric_serialization_test.cpp
+++ b/cloudwatch_metrics_common/test/metric_serialization_test.cpp
@@ -33,7 +33,7 @@ TEST_F(TestMetricSerialization, deserialize_returns_metric_datum) {
 
   MetricDatum result;
   EXPECT_NO_THROW(result = deserializeMetricDatum(mock_serialized_metric_datum));
-  Aws::Utils::DateTime ts((int64_t)5);
+  Aws::Utils::DateTime ts(static_cast<int64_t>(5));
   EXPECT_EQ(result.GetTimestamp(), ts);
   EXPECT_EQ(result.GetMetricName(), "awesomeness");
   auto expected_counts = Aws::Vector<double>();

--- a/dataflow_lite/include/dataflow_lite/dataflow/observed_queue.h
+++ b/dataflow_lite/include/dataflow_lite/dataflow/observed_queue.h
@@ -53,7 +53,7 @@ class ObservedQueue :
   public IObservedQueue<T, Allocator> {
 public:
 
-  virtual ~ObservedQueue() = default;
+  ~ObservedQueue() override = default;
 
   /**
    * Set the observer for the queue.
@@ -138,7 +138,7 @@ public:
   /**
    * Clear the dequeue
    */
-  void clear() {
+  void clear() override {
     dequeue_.clear();
   }
 
@@ -178,7 +178,7 @@ template<
     class Allocator = std::allocator<T>>
 class ObservedSynchronizedQueue : public ObservedQueue<T, Allocator> {
 public:
-  virtual ~ObservedSynchronizedQueue() = default;
+  ~ObservedSynchronizedQueue() override = default;
 
   /**
    * Enqueue data and notify the observer of data available.
@@ -260,7 +260,7 @@ public:
   /**
    * Clear the dequeue
    */
-  void clear() {
+  void clear() override {
     std::unique_lock<DequeueMutex> lock(dequeue_mutex_);
     OQ::clear();
   }
@@ -296,7 +296,7 @@ public:
     max_queue_size_ = max_queue_size;
   }
 
-  virtual ~ObservedBlockingQueue() = default;
+  ~ObservedBlockingQueue() override = default;
   /**
    * Enqueue data and notify the observer of data available.
    *
@@ -385,7 +385,7 @@ public:
   /**
    * Clear the dequeue
    */
-  void clear() {
+  void clear() override {
     std::lock_guard<std::mutex> lock(dequeue_mutex_);
     OQ::clear();
   }

--- a/dataflow_lite/include/dataflow_lite/dataflow/queue_monitor.h
+++ b/dataflow_lite/include/dataflow_lite/dataflow/queue_monitor.h
@@ -46,7 +46,7 @@ class QueueMonitor :
 {
 public:
   QueueMonitor() = default;
-  virtual ~QueueMonitor() = default;
+  ~QueueMonitor() override = default;
 
   inline void addSource(
     std::shared_ptr<IObservedQueue < T>>observed_queue,

--- a/dataflow_lite/include/dataflow_lite/task/task.h
+++ b/dataflow_lite/include/dataflow_lite/task/task.h
@@ -111,7 +111,7 @@ public:
 
     virtual ~BasicTask() = default;
 
-    virtual void onComplete(const UploadStatus &status) override {
+    void onComplete(const UploadStatus &status) override {
       if (upload_status_function_) {
         upload_status_function_(status, *batch_data_);
       }
@@ -133,5 +133,5 @@ private:
     UploadStatusFunction<UploadStatus, T> upload_status_function_;
 };
 
-}
-}
+}  // namespace DataFlow
+}  // namespace Aws

--- a/dataflow_lite/include/dataflow_lite/utils/data_batcher.h
+++ b/dataflow_lite/include/dataflow_lite/utils/data_batcher.h
@@ -50,7 +50,8 @@ public:
    * @param trigger_size if this limit is reached then the queue is emptied via the publish method
    * @param try_enqueue_duration maximum amount of time to attempt to empty queue during the publish method
    */
-  explicit DataBatcher(size_t max_allowable_batch_size = DataBatcher::kDefaultMaxBatchSize,
+  // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
+  DataBatcher(size_t max_allowable_batch_size = DataBatcher::kDefaultMaxBatchSize,
               size_t trigger_size = DataBatcher::kDefaultTriggerSize,
               std::chrono::microseconds try_enqueue_duration = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::seconds(2))) {
 

--- a/dataflow_lite/include/dataflow_lite/utils/data_batcher.h
+++ b/dataflow_lite/include/dataflow_lite/utils/data_batcher.h
@@ -109,7 +109,7 @@ public:
   /**
    * Reset the batched data shared pointer.
    */
-  virtual void resetBatchedData() {
+  void resetBatchedData() {
     std::lock_guard<std::recursive_mutex> lk(mtx);
 
     this->batched_data_ = std::make_shared<std::list<T>>();

--- a/dataflow_lite/include/dataflow_lite/utils/data_batcher.h
+++ b/dataflow_lite/include/dataflow_lite/utils/data_batcher.h
@@ -50,7 +50,7 @@ public:
    * @param trigger_size if this limit is reached then the queue is emptied via the publish method
    * @param try_enqueue_duration maximum amount of time to attempt to empty queue during the publish method
    */
-  DataBatcher(size_t max_allowable_batch_size = DataBatcher::kDefaultMaxBatchSize,
+  explicit DataBatcher(size_t max_allowable_batch_size = DataBatcher::kDefaultMaxBatchSize,
               size_t trigger_size = DataBatcher::kDefaultTriggerSize,
               std::chrono::microseconds try_enqueue_duration = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::seconds(2))) {
 
@@ -66,7 +66,7 @@ public:
   /**
    * Destruct a DataBatcher instance
    */
-  ~DataBatcher() = default;
+  ~DataBatcher() override = default;
 
   /**
    * Batch an item.
@@ -213,7 +213,7 @@ public:
    * Shutdown the batcher: this blocks until publish has completed in order to attempt to empty any unpublished data.
    * @return the result of Service::shutdown()
    */
-  bool shutdown() {
+  bool shutdown() override {
     bool is_shutdown = Service::shutdown();
     std::lock_guard<std::recursive_mutex> lk(mtx);
     this->emptyCollection();  // attempt to write to disk before discarding
@@ -239,8 +239,8 @@ private:
     /**
      * Size used for the internal storage
      */
-    std::atomic<size_t> max_allowable_batch_size_;
-    std::atomic<size_t> trigger_batch_size_;
-    std::atomic<std::chrono::microseconds> try_enqueue_duration_;
+    std::atomic<size_t> max_allowable_batch_size_{};
+    std::atomic<size_t> trigger_batch_size_{};
+    std::atomic<std::chrono::microseconds> try_enqueue_duration_{};
 };
 

--- a/dataflow_lite/include/dataflow_lite/utils/observable_object.h
+++ b/dataflow_lite/include/dataflow_lite/utils/observable_object.h
@@ -36,7 +36,7 @@ public:
      *
      * @param initialValue
      */
-    ObservableObject<T>(const T initialValue) {
+    explicit ObservableObject<T>(const T initialValue) {
       value_.store(initialValue);
     }
     /**

--- a/dataflow_lite/include/dataflow_lite/utils/observable_object.h
+++ b/dataflow_lite/include/dataflow_lite/utils/observable_object.h
@@ -36,7 +36,8 @@ public:
      *
      * @param initialValue
      */
-    explicit ObservableObject<T>(const T initialValue) {
+    // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
+    ObservableObject<T>(const T initialValue) {
       value_.store(initialValue);
     }
     /**

--- a/dataflow_lite/include/dataflow_lite/utils/observable_object.h
+++ b/dataflow_lite/include/dataflow_lite/utils/observable_object.h
@@ -94,7 +94,7 @@ public:
     /**
      * Clear all active listeners
      */
-    virtual void clearListeners() {
+    void clearListeners() {
       std::lock_guard<std::recursive_mutex> lk(listener_mutex_);
       listeners_.clear();
     }

--- a/dataflow_lite/include/dataflow_lite/utils/publisher.h
+++ b/dataflow_lite/include/dataflow_lite/utils/publisher.h
@@ -54,7 +54,7 @@ public:
       last_publish_duration_.store(std::chrono::milliseconds(0));
     }
 
-    virtual ~Publisher() = default;
+    ~Publisher() override = default;
 
     /**
      * Return the current state of the publisher.
@@ -72,7 +72,7 @@ public:
      * @return the resulting Aws::DataFlow::UploadStatus from the publish attempt. Returns FAIL if not in the started
      * state.
      */
-    virtual Aws::DataFlow::UploadStatus attemptPublish(T &data) override {
+    Aws::DataFlow::UploadStatus attemptPublish(T &data) override {
 
       // don't attempt to publish if not in the started state
       if(ServiceState::STARTED != this->getState()) {
@@ -105,7 +105,7 @@ public:
      * Shutdown the publisher. This waits for attemptPublish to finish before returning.
      * @return the result of shutdown
      */
-    virtual bool shutdown() override {
+    bool shutdown() override {
       bool b = Service::shutdown();  // set shutdown state to try and fast fail any publish calls
 
       std::lock_guard<std::mutex> lck (publish_mutex_);
@@ -160,7 +160,7 @@ public:
         return 0;
       }
       int successes = publish_successes_.load();
-      return (float) successes / (float) attempts * 100.0f;
+      return static_cast<float>(successes) / static_cast<float>(attempts) * 100.0f;
     }
 
     /**
@@ -191,15 +191,15 @@ private:
     /**
      * Number of publish successes
      */
-    std::atomic<int> publish_successes_;
+    std::atomic<int> publish_successes_{};
     /**
      * Number of publish attempts
      */
-    std::atomic<int> publish_attempts_;
+    std::atomic<int> publish_attempts_{};
     /**
      * The amount of time taken for the last publish action
      */
-    std::atomic<std::chrono::milliseconds> last_publish_duration_;
+    std::atomic<std::chrono::milliseconds> last_publish_duration_{};
     /**
      * Mutex used in publish and shutdown
      */

--- a/dataflow_lite/include/dataflow_lite/utils/service.h
+++ b/dataflow_lite/include/dataflow_lite/utils/service.h
@@ -131,13 +131,13 @@ public:
     RunnableService() {
       should_run_.store(false);
     }
-    virtual ~RunnableService() = default;
+    ~RunnableService() override = default;
 
     /**
      * Starts the worker thread. Should be overridden if other actions are necessary to start.
      * @return
      */
-    virtual bool start() override {
+    bool start() override {
       bool started = startWorkerThread();
       started &= Service::start();
       return started;
@@ -147,7 +147,7 @@ public:
      * Stops the worker thread. Should be overridden if other actions are necessary to stop.
      * @return
      */
-    virtual bool shutdown() override {
+    bool shutdown() override {
       bool is_shutdown = Service::shutdown();
       is_shutdown &= stopWorkerThread();
       return is_shutdown;
@@ -195,7 +195,7 @@ public:
      * Return a descriptive string describing the service and it's state.
      * @return
      */
-    virtual std::string getStatusString() override {
+    std::string getStatusString() override {
       return Service::getStatusString() + std::string(", isRunning=") + (isRunning()
         ? std::string("True") : std::string("False"));
     }
@@ -246,7 +246,7 @@ protected:
 
 private:
   std::thread runnable_thread_;
-  std::atomic<bool> should_run_;
+  std::atomic<bool> should_run_{};
   std::condition_variable cv_;
   mutable std::mutex mtx_;
 };

--- a/dataflow_lite/src/dataflow/status_monitor.cpp
+++ b/dataflow_lite/src/dataflow/status_monitor.cpp
@@ -17,7 +17,9 @@
 
 #include <dataflow_lite/dataflow/status_monitor.h>
 
-using namespace Aws::DataFlow;
+namespace Aws {
+namespace DataFlow {
+
 void StatusMonitor::setStatus(const Status &status) {
   status_ = status;
   if (multi_status_cond_) {
@@ -71,3 +73,6 @@ void MultiStatusConditionMonitor::setStatus(
 bool MultiStatusConditionMonitor::hasWork() {
   return mask_factory_.getCollectiveMask() == mask_;
 }
+
+}  // namespace DataFlow
+}  // namespace Aws

--- a/dataflow_lite/test/dataflow/queue_monitor_test.cpp
+++ b/dataflow_lite/test/dataflow/queue_monitor_test.cpp
@@ -86,7 +86,7 @@ TEST(queue_demux_test, single_source_test)
   std::shared_ptr<StatusMonitor> monitor;
   std::string actual = "test_string";
   EXPECT_CALL(*observed_queue, dequeue(_, _))
-    .WillOnce(Invoke([=](auto && arg1, auto && arg2) { return dequeueFunc(arg1, actual, arg2); };));
+    .WillOnce(Invoke([=](auto && arg1, auto && arg2) { return dequeueFunc(arg1, actual, arg2); }));
   QueueMonitor<std::string> queue_monitor;
   queue_monitor.addSource(observed_queue, PriorityOptions());
   std::string data;
@@ -99,14 +99,14 @@ TEST(queue_demux_test, multi_source_test)
   QueueMonitor<std::string> queue_monitor;
   auto low_priority_queue = std::make_shared<StrictMock<MockObservedQueue>>();
   EXPECT_CALL(*low_priority_queue, dequeue(_, _))
-    .WillOnce(Invoke([=](auto && arg1, auto && arg2) { return dequeueFunc(arg1, "low_priority", arg2); };))
+    .WillOnce(Invoke([=](auto && arg1, auto && arg2) { return dequeueFunc(arg1, "low_priority", arg2); }))
     .WillRepeatedly(Return(false));
   queue_monitor.addSource(low_priority_queue, PriorityOptions(LOWEST_PRIORITY));
 
   auto high_priority_observed_queue = std::make_shared<StrictMock<MockObservedQueue>>();
   std::shared_ptr<StatusMonitor> monitor;
   EXPECT_CALL(*high_priority_observed_queue, dequeue(_, _))
-    .WillOnce(Invoke([=](auto && arg1, auto && arg2) { return dequeueFunc(arg1, "high_priority", arg2); };))
+    .WillOnce(Invoke([=](auto && arg1, auto && arg2) { return dequeueFunc(arg1, "high_priority", arg2); }))
     .WillRepeatedly(Return(false));;
   queue_monitor.addSource(high_priority_observed_queue, PriorityOptions(HIGHEST_PRIORITY));
   std::string data;

--- a/dataflow_lite/test/dataflow/queue_monitor_test.cpp
+++ b/dataflow_lite/test/dataflow/queue_monitor_test.cpp
@@ -86,7 +86,7 @@ TEST(queue_demux_test, single_source_test)
   std::shared_ptr<StatusMonitor> monitor;
   std::string actual = "test_string";
   EXPECT_CALL(*observed_queue, dequeue(_, _))
-    .WillOnce(Invoke(std::bind(dequeueFunc, _1, actual, _2)));
+    .WillOnce(Invoke([=](auto && arg1, auto && arg2) { return dequeueFunc(arg1, actual, arg2); };));
   QueueMonitor<std::string> queue_monitor;
   queue_monitor.addSource(observed_queue, PriorityOptions());
   std::string data;
@@ -99,14 +99,14 @@ TEST(queue_demux_test, multi_source_test)
   QueueMonitor<std::string> queue_monitor;
   auto low_priority_queue = std::make_shared<StrictMock<MockObservedQueue>>();
   EXPECT_CALL(*low_priority_queue, dequeue(_, _))
-    .WillOnce(Invoke(std::bind(dequeueFunc, _1, "low_priority", _2)))
+    .WillOnce(Invoke([=](auto && arg1, auto && arg2) { return dequeueFunc(arg1, "low_priority", arg2); };))
     .WillRepeatedly(Return(false));
   queue_monitor.addSource(low_priority_queue, PriorityOptions(LOWEST_PRIORITY));
 
   auto high_priority_observed_queue = std::make_shared<StrictMock<MockObservedQueue>>();
   std::shared_ptr<StatusMonitor> monitor;
   EXPECT_CALL(*high_priority_observed_queue, dequeue(_, _))
-    .WillOnce(Invoke(std::bind(dequeueFunc, _1, "high_priority", _2)))
+    .WillOnce(Invoke([=](auto && arg1, auto && arg2) { return dequeueFunc(arg1, "high_priority", arg2); };))
     .WillRepeatedly(Return(false));;
   queue_monitor.addSource(high_priority_observed_queue, PriorityOptions(HIGHEST_PRIORITY));
   std::string data;

--- a/dataflow_lite/test/utils/data_batcher_test.cpp
+++ b/dataflow_lite/test/utils/data_batcher_test.cpp
@@ -27,7 +27,7 @@
 class TestBatcher : public DataBatcher<int> {
 public:
 
-  TestBatcher(size_t max_allowable_batch_size = DataBatcher::kDefaultMaxBatchSize,
+  explicit TestBatcher(size_t max_allowable_batch_size = DataBatcher::kDefaultMaxBatchSize,
           size_t publish_trigger_size = DataBatcher::kDefaultTriggerSize) : DataBatcher(max_allowable_batch_size, publish_trigger_size) {
     pub_called = 0;
   }

--- a/dataflow_lite/test/utils/publisher_test.cpp
+++ b/dataflow_lite/test/utils/publisher_test.cpp
@@ -28,9 +28,9 @@ class SimpleTestPublisher : public Publisher<std::string>
 public:
 
   SimpleTestPublisher() {should_succeed_ = true;}
-  ~SimpleTestPublisher() = default;
+  ~SimpleTestPublisher() override = default;
 
-  virtual Aws::DataFlow::UploadStatus publishData(std::string &data) override {
+  Aws::DataFlow::UploadStatus publishData(std::string &data) override {
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
     last_data = data;
     return  should_succeed_ ? Aws::DataFlow::UploadStatus::SUCCESS : Aws::DataFlow::UploadStatus::FAIL;

--- a/dataflow_lite/test/utils/runnable_service_test.cpp
+++ b/dataflow_lite/test/utils/runnable_service_test.cpp
@@ -31,15 +31,15 @@ public:
       has_worked_ = false;
     };
 
-    ~HardWorker() = default;
+    ~HardWorker() override = default;
 
-    virtual bool shutdown() {
+    bool shutdown() override {
       std::unique_lock <std::mutex> lck(this->test_mtx);
       this->test_cv.notify_all(); // stop blocking in the work thread
       return RunnableService::shutdown();
     }
 
-    virtual void work() override {
+    void work() override {
       this->has_worked_ = true;
 
       // manually wait for shutdown

--- a/file_management/include/file_management/file_manager_options.h
+++ b/file_management/include/file_management/file_manager_options.h
@@ -28,6 +28,20 @@ struct TokenStoreOptions {
 };
 
 struct FileManagerStrategyOptions {
+  FileManagerStrategyOptions() = default;
+
+  FileManagerStrategyOptions(
+    std::string _storage_directory,
+    std::string _file_prefix,
+    std::string _file_extension,
+    size_t _maximum_file_size,
+    size_t _storage_limit)
+    : storage_directory(std::move(_storage_directory)),
+      file_prefix(std::move(_file_prefix)),
+      file_extension(std::move(_file_extension)),
+      maximum_file_size_in_kb(_maximum_file_size),
+      storage_limit_in_kb(_storage_limit) {}
+
   /**
    * The path to the folder where all files are stored. Can be absolute or relative
    */
@@ -44,12 +58,12 @@ struct FileManagerStrategyOptions {
    * The maximum size of any single file in storage.
    * After this limit is reached the file will be rotated.
    */
-  size_t maximum_file_size_in_kb;
+  size_t maximum_file_size_in_kb{};
   /**
    * The maximum size of all files on disk.
    * After this limit is reached files will start to be deleted, oldest first.
    */
-  size_t storage_limit_in_kb;
+  size_t storage_limit_in_kb{};
 };
 
 static const FileManagerStrategyOptions kDefaultFileManagerStrategyOptions{"~/.ros/cwlogs", "cwlog", ".log", 1024, 1024*1024};

--- a/file_management/include/file_management/file_upload/file_manager.h
+++ b/file_management/include/file_management/file_upload/file_manager.h
@@ -93,7 +93,8 @@ public:
    *
    * @param options for the FileManagerStrategy
    */
-  explicit FileManager(const FileManagerStrategyOptions &options) {
+  // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
+  FileManager(const FileManagerStrategyOptions &options) {
     file_manager_strategy_ = std::make_shared<FileManagerStrategy>(options);
   }
 

--- a/file_management/include/file_management/file_upload/file_manager.h
+++ b/file_management/include/file_management/file_upload/file_manager.h
@@ -36,7 +36,7 @@ template <typename T>
 class FileObject {
 public:
   T batch_data;
-  size_t batch_size;
+  size_t batch_size{};
   std::list<DataToken> data_tokens;
 };
 
@@ -93,7 +93,7 @@ public:
    *
    * @param options for the FileManagerStrategy
    */
-  FileManager(const FileManagerStrategyOptions &options) {
+  explicit FileManager(const FileManagerStrategyOptions &options) {
     file_manager_strategy_ = std::make_shared<FileManagerStrategy>(options);
   }
 
@@ -110,7 +110,7 @@ public:
     }
   }
 
-  virtual bool start() override {
+  bool start() override {
     bool started = true;
     if(file_manager_strategy_) {
       started &= file_manager_strategy_->start();
@@ -122,7 +122,7 @@ public:
     return started;
   }
 
-  virtual bool shutdown() override {
+  bool shutdown() override {
     bool is_shutdown = Service::shutdown();
     if(file_manager_strategy_) {
       file_status_monitor_->setStatus(Aws::DataFlow::Status::UNAVAILABLE);
@@ -161,7 +161,7 @@ public:
  * @param upload_status the status of an attempted upload of data
  * @param log_messages the data which was attempted to be uploaded
  */
-  virtual void fileUploadCompleteStatus(
+  void fileUploadCompleteStatus(
       const Aws::DataFlow::UploadStatus& upload_status,
       const FileObject<T> &log_messages) override {
     if (Aws::DataFlow::UploadStatus::SUCCESS == upload_status) {

--- a/file_management/include/file_management/file_upload/file_manager_strategy.h
+++ b/file_management/include/file_management/file_upload/file_manager_strategy.h
@@ -13,7 +13,6 @@
  * permissions and limitations under the License.
  */
 
-
 #pragma once
 
 #include <iostream>
@@ -59,6 +58,7 @@ public:
 
   FileTokenInfo() = default;
 
+  // NOLINTNEXTLINE(google-runtime-int)
   explicit FileTokenInfo(const std::string &file_path, const long position, const bool eof) :
   file_path_{file_path},
   position_(position),
@@ -67,6 +67,7 @@ public:
 
   };
 
+  // NOLINTNEXTLINE(google-runtime-int)
   explicit FileTokenInfo(std::string &&file_path, const long position, const bool eof) :
       file_path_{std::move(file_path)},
       position_(position),
@@ -75,7 +76,11 @@ public:
 
   };
 
-  FileTokenInfo(const FileTokenInfo & info) = default;
+  FileTokenInfo(const FileTokenInfo &info) = default;
+
+  FileTokenInfo & operator=(const FileTokenInfo & other) = default;
+
+  ~FileTokenInfo() = default;
 
   /**
    * Serializes a tokens information into a JSON string
@@ -115,7 +120,7 @@ public:
   /** 
    * The position in the file that this token corrosponds to
    */
-  long position_ = 0;
+  int64_t position_ = 0;
 
   /**
    * Set to true if this is the last token for the file
@@ -180,7 +185,8 @@ public:
    * @param is_eof
    * @return
    */
-  DataToken createToken(const std::string &file_name, const long & streampos, bool is_eof);
+  // NOLINTNEXTLINE(google-runtime-int)
+  DataToken createToken(const std::string &file_name, const long streampos, bool is_eof);
 
   /**
    * Mark a token as failed so the FileManagerStrategy knows to keep the 
@@ -455,12 +461,6 @@ private:
    * Options for how and where to store files, and maximum file sizes.
    */
   FileManagerStrategyOptions options_;
-
-  /**
-   * Size of each batch when reading from a file.
-   * The Size corresponds to the number of lines read from the file
-   */
-  uint8_t batch_size = 1;
 
   /**
    * Stores which tokens to read from.

--- a/file_management/include/file_management/file_upload/file_manager_strategy.h
+++ b/file_management/include/file_management/file_upload/file_manager_strategy.h
@@ -75,13 +75,7 @@ public:
 
   };
 
-  FileTokenInfo(const FileTokenInfo &info) :
-      file_path_{info.file_path_},
-      position_(info.position_),
-      eof_(info.eof_)
-  {
-
-  };
+  FileTokenInfo(const FileTokenInfo & info) = default;
 
   /**
    * Serializes a tokens information into a JSON string
@@ -101,7 +95,7 @@ public:
    * Takes a Token JSON string and sets this tokens
    * values based on that. 
    */
-  void deserialize(const std::string token_info_json) {
+  void deserialize(const std::string& token_info_json) {
     const Aws::String aws_str(token_info_json.c_str());
     const Aws::Utils::Json::JsonValue json_value(aws_str);
     if (!json_value.WasParseSuccessful()) {
@@ -126,7 +120,7 @@ public:
   /**
    * Set to true if this is the last token for the file
    */
-  bool eof_;
+  bool eof_{};
 };
 
 inline bool operator==(const FileTokenInfo& lhs, const FileTokenInfo& rhs){
@@ -138,7 +132,7 @@ inline bool operator!=(const FileTokenInfo& lhs, const FileTokenInfo& rhs){ retu
 class DataManagerStrategy : public Service {
 public:
   DataManagerStrategy() = default;
-  virtual ~DataManagerStrategy() = default;
+  ~DataManagerStrategy() override = default;
 
   virtual bool isDataAvailable() = 0;
 
@@ -284,7 +278,7 @@ class FileManagerStrategy : public DataManagerStrategy {
 public:
   explicit FileManagerStrategy(const FileManagerStrategyOptions &options);
 
-  ~FileManagerStrategy() = default;
+  ~FileManagerStrategy() override = default;
 
   /**
    * Starts the FileManagerStrategy, this does any initialization I/O tasks required.
@@ -421,7 +415,7 @@ private:
   /**
    * Disk space used by all stored files. Does not include active_write_file_size_.
    */
-  std::atomic<size_t> stored_files_size_;
+  std::atomic<size_t> stored_files_size_{};
 
   /**
    * Path to the file we're currently writing to. This file cannot be read from or deleted. 
@@ -431,7 +425,7 @@ private:
   /** 
    * The size of the active_write_file. Stored here to minimize disk reads. 
    */
-  std::atomic<size_t> active_write_file_size_;
+  std::atomic<size_t> active_write_file_size_{};
 
   /** 
    * A lock on the active write file, to ensure that when it's rotated nothing is writing 

--- a/file_management/include/file_management/file_upload/file_upload_streamer.h
+++ b/file_management/include/file_management/file_upload/file_upload_streamer.h
@@ -83,7 +83,7 @@ public:
     status_monitor_timeout_ = kTimeout;
   }
 
-  virtual ~FileUploadStreamer() = default;
+  ~FileUploadStreamer() override = default;
 
   /**
    * Add a status monitor for the file upload manager to wait for work on.
@@ -94,7 +94,7 @@ public:
     status_condition_monitor_.addStatusMonitor(status_monitor);
   }
 
-  inline bool shutdown() {
+  inline bool shutdown() override {
     bool is_shutdown = true;
     is_shutdown &= RunnableService::shutdown();
     is_shutdown &= data_reader_->shutdown();
@@ -122,7 +122,7 @@ public:
   /**
    * Start the upload thread.
    */
-  bool start() {
+  bool start() override {
     bool is_started = true;
     is_started &= data_reader_->start();
     is_started &= RunnableService::start();

--- a/file_management/include/file_management/file_upload/file_upload_task.h
+++ b/file_management/include/file_management/file_upload/file_upload_task.h
@@ -49,7 +49,7 @@ class FileUploadTask : public Aws::DataFlow::Task<T> {
     this->upload_status_function_ = upload_status_function;
   }
 
-  virtual ~FileUploadTask() = default;
+  ~FileUploadTask() override = default;
 
   void onComplete(const Aws::DataFlow::UploadStatus &status) override {
     if (upload_status_function_) {

--- a/file_management/src/file_upload/file_manager_strategy.cpp
+++ b/file_management/src/file_upload/file_manager_strategy.cpp
@@ -22,7 +22,7 @@
 #include <iomanip>
 #include "file_management/file_upload/file_manager_strategy.h"
 
-#define KB_TO_BYTES(x) ((size_t) (x) << 10)
+#define KB_TO_BYTES(x) (static_cast<size_t>(x) << 10u)
 
 namespace fs = std::experimental::filesystem;
 
@@ -107,9 +107,9 @@ void printCache(std::unordered_map<DataToken, FileTokenInfo> token_store,
                "Cache Info: staged_tokens \n %s", ss.str().c_str());
 }
 
-DataToken TokenStore::createToken(const std::string &file_name, const long & streampos, bool is_eof) {
-  AWS_LOG_DEBUG(__func__,
-               "Creating token");
+// NOLINTNEXTLINE(google-runtime-int)
+DataToken TokenStore::createToken(const std::string &file_name, const long streampos, bool is_eof) {
+  AWS_LOG_DEBUG(__func__, "Creating token");
   std::mt19937_64 rand( rand_device() );
   DataToken token = rand();
   token_store_.emplace(token, FileTokenInfo(file_name, streampos, is_eof));
@@ -215,7 +215,7 @@ void TokenStore::restoreFromDisk() {
       FileTokenInfo token_info;
       try {
         token_info.deserialize(line);
-      } catch (std::runtime_error e) {
+      } catch (const std::runtime_error & e) {
         AWS_LOG_ERROR(__func__, "Unable to parse token backup line: %s. Skipping.", line.c_str());
         continue;
       }
@@ -309,11 +309,11 @@ DataToken FileManagerStrategy::read(std::string &data) {
     FileTokenInfo file_token = token_store_->popAvailableToken(active_read_file_);
     active_read_file_stream_->seekg(file_token.position_);
   }
-  long position = active_read_file_stream_->tellg();
+  int position = active_read_file_stream_->tellg();
   auto file_size = active_read_file_stream_->seekg(0, std::ifstream::end).tellg();
   active_read_file_stream_->seekg(position, std::ifstream::beg);
   std::getline(*active_read_file_stream_, data);
-  long next_position = active_read_file_stream_->tellg();
+  int next_position = active_read_file_stream_->tellg();
   token = token_store_->createToken(active_read_file_, position, next_position >= file_size);
 
   if (next_position >= file_size) {

--- a/file_management/src/file_upload/file_manager_strategy.cpp
+++ b/file_management/src/file_upload/file_manager_strategy.cpp
@@ -37,11 +37,11 @@ void sanitizePath(std::string & path) {
   }
   if (path.front() == '~') {
     char * home = getenv("HOME");
-    if (NULL == home) {
+    if (nullptr == home) {
       AWS_LOG_WARN(__func__, "No HOME environment variable set. Attempting to use ROS_HOME instead.");
       home = getenv("ROS_HOME");
     }
-    if (NULL != home) {
+    if (nullptr != home) {
       path.replace(0, 1, home);
     } else {
       throw std::runtime_error("The storage directory path uses '~' but no HOME environment variable set.");

--- a/file_management/test/file_management/file_manager_strategy_test.cpp
+++ b/file_management/test/file_management/file_manager_strategy_test.cpp
@@ -32,7 +32,7 @@ using namespace Aws::FileManagement;
 
 class MockFileManagerStrategy : public FileManagerStrategy {
 public:
-  MockFileManagerStrategy(const FileManagerStrategyOptions &options) : FileManagerStrategy(options) {}
+  explicit MockFileManagerStrategy(const FileManagerStrategyOptions &options) : FileManagerStrategy(options) {}
 
   std::string getFileToRead() {
     return FileManagerStrategy::getFileToRead();
@@ -308,7 +308,7 @@ TEST_F(SanitizePathTest, sanitizePath_home_set) {
   sanitizePath(test_path);
 
   // Cleanup before test
-  if (NULL != original_home) {
+  if (nullptr != original_home) {
     setenv("HOME", original_home, 1);
   } else {
     unsetenv("HOME");
@@ -327,10 +327,10 @@ TEST_F(SanitizePathTest, sanitizePath_home_not_set_roshome_set) {
   sanitizePath(test_path);
 
   // Cleanup before test
-  if (NULL != original_home) {
+  if (nullptr != original_home) {
     setenv("HOME", original_home, 1);
   }
-  if (NULL != original_ros_home) {
+  if (nullptr != original_ros_home) {
     setenv("ROS_HOME", original_ros_home, 1);
   } else {
     unsetenv("ROS_HOME");
@@ -351,10 +351,10 @@ TEST_F(SanitizePathTest, sanitizePath_home_not_set_roshome_not_set) {
   ASSERT_THROW(sanitizePath(test_path), std::runtime_error);
 
   // Cleanup before test
-  if (NULL != original_home) {
+  if (nullptr != original_home) {
     setenv("HOME", original_home, 1);
   }
-  if (NULL != original_ros_home) {
+  if (nullptr != original_ros_home) {
     setenv("ROS_HOME", original_ros_home, 1);
   }
 

--- a/file_management/test/file_management/file_upload_streamer_test.cpp
+++ b/file_management/test/file_management/file_upload_streamer_test.cpp
@@ -133,7 +133,7 @@ TEST_F(FileStreamerTest, fail_enqueue_retry) {
   test_file_object.batch_data = "data";
   test_file_object.batch_size = 1;
   SharedFileUploadTask task;
-  // TODO: capture and test equivalence
+  // TODO(unknown): capture and test equivalence
   EXPECT_CALL(*mock_sink, tryEnqueue(testing::_, testing::_))
       .WillOnce(testing::Invoke([&task](SharedFileUploadTask& data,
                                         const std::chrono::microseconds&){
@@ -160,7 +160,7 @@ TEST_F(FileStreamerTest, fail_task_clears_queue) {
   test_file_object.batch_data = "data";
   test_file_object.batch_size = 1;
   SharedFileUploadTask task;
-  // TODO: capture and test equivalence
+  // TODO(unknown): capture and test equivalence
   EXPECT_CALL(*mock_sink, tryEnqueue(testing::_, testing::_))
     .WillOnce(testing::Invoke([&task](SharedFileUploadTask& data,
                                       const std::chrono::microseconds&){


### PR DESCRIPTION
*Description of changes:*

Fixing linting issues found by `clang-tidy` 6.0, without introducing public API changes (there may be ABI changes though).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.