### PR TITLE
add error for invalid log batch

### DIFF
--- a/cloudwatch_logs_common/CMakeLists.txt
+++ b/cloudwatch_logs_common/CMakeLists.txt
@@ -106,7 +106,7 @@ if(GMOCK_LIBRARY)
           test/pipeline_test.cpp
           )
 
-  add_common_gtest(file_manager_test
+  add_common_gtest(test_file_manager
           test/file_manager_test.cpp
           )
 
@@ -125,5 +125,6 @@ if(GMOCK_LIBRARY)
 
   link_test_target(test_cloudwatch_logs_common)
   link_test_target(test_pipelines)
+  link_test_target(test_file_manager)
 
 endif()

--- a/cloudwatch_logs_common/CMakeLists.txt
+++ b/cloudwatch_logs_common/CMakeLists.txt
@@ -106,8 +106,8 @@ if(GMOCK_LIBRARY)
           test/pipeline_test.cpp
           )
 
-  add_common_gtest(test_file_manager
-          test/file_manager_test.cpp
+  add_common_gtest(test_log_batch
+          test/log_batch_test.cpp
           )
 
   set(LIBS_FOR_TESTS
@@ -125,6 +125,6 @@ if(GMOCK_LIBRARY)
 
   link_test_target(test_cloudwatch_logs_common)
   link_test_target(test_pipelines)
-  link_test_target(test_file_manager)
+  link_test_target(test_log_batch)
 
 endif()

--- a/cloudwatch_logs_common/CMakeLists.txt
+++ b/cloudwatch_logs_common/CMakeLists.txt
@@ -106,6 +106,10 @@ if(GMOCK_LIBRARY)
           test/pipeline_test.cpp
           )
 
+  add_common_gtest(file_manager_test
+          test/file_manager_test.cpp
+          )
+
   set(LIBS_FOR_TESTS
           ${GTEST_LIBRARIES}
           pthread

--- a/cloudwatch_logs_common/include/cloudwatch_logs_common/utils/log_file_manager.h
+++ b/cloudwatch_logs_common/include/cloudwatch_logs_common/utils/log_file_manager.h
@@ -44,7 +44,7 @@ class LogFileManager :
     : FileManager(options) {
   }
 
-  explicit LogFileManager(const std::shared_ptr<FileManagerStrategy> &file_manager_strategy)
+  explicit LogFileManager(const std::shared_ptr<Aws::FileManagement::DataManagerStrategy> &file_manager_strategy)
       : FileManager(file_manager_strategy)
   {
   }

--- a/cloudwatch_logs_common/src/utils/log_file_manager.cpp
+++ b/cloudwatch_logs_common/src/utils/log_file_manager.cpp
@@ -89,9 +89,8 @@ FileObject<LogCollection> LogFileManager::readBatch(
     }
     else{
       AWS_LOG_INFO(__func__, "Some logs were not batched since the time"
-        + " difference was > 24 hours. Will try again in a separate batch./n"
-        + "Logs read: " + std::to_string(batch_size)
-        + ", Logs batched: " + std::to_string(log_data.size())
+        " difference was > 24 hours. Will try again in a separate batch./n"
+        "Logs read: %d, Logs batched: %d", batch_size, log_data.size()
         );
       break;
     }

--- a/cloudwatch_logs_common/src/utils/log_file_manager.cpp
+++ b/cloudwatch_logs_common/src/utils/log_file_manager.cpp
@@ -28,7 +28,7 @@
 #include <aws/core/utils/logging/LogMacros.h>
 #include <cloudwatch_logs_common/definitions/definitions.h>
 
-#define HOURS24 86400000
+const long ONE_DAY_IN_SEC = 86400000;
 
 namespace Aws {
 namespace CloudWatchLogs {
@@ -67,7 +67,7 @@ FileObject<LogCollection> LogFileManager::readBatch(
     long curTime = std::get<0>(pq.top());
     std::string line = std::get<1>(pq.top());
     FileManagement::DataToken new_data_token = std::get<2>(pq.top());
-    if(latestTime - curTime < HOURS24){
+    if(latestTime - curTime < ONE_DAY_IN_SEC){
       Aws::String aws_line(line.c_str());
       Aws::Utils::Json::JsonValue value(aws_line);
       Aws::CloudWatchLogs::Model::InputLogEvent input_event(value);

--- a/cloudwatch_logs_common/src/utils/log_file_manager.cpp
+++ b/cloudwatch_logs_common/src/utils/log_file_manager.cpp
@@ -35,8 +35,19 @@ FileObject<LogCollection> LogFileManager::readBatch(
   /* We must sort the log data chronologically because it is not guaranteed
      to be ordered chronologically in the file, but CloudWatch requires all
      puts in a single batch to be sorted chronologically */
-  auto log_comparison = [](const LogType & log1, const LogType & log2)
-    { return log1.GetTimestamp() < log2.GetTimestamp(); };
+  auto log_comparison = [](const LogType & log1, const LogType & log2) { 
+      typedef std::chrono::high_resolution_clock Clock;
+      typedef std::chrono::hours hours;
+      Clock::time_point t0 = log1.GetTimestamp();
+      Clock::time_point t1 = log2.GetTimestamp();
+      hours hrs = std::chrono::duration_cast<hrs>(t1 - t0);
+
+      if(hrs >= 24){
+        AWS_LOGSTREAM_ERROR(__func__, "The logs in this batch exceed a 24 hour time duration.");
+      }
+
+      return log1.GetTimestamp() < log2.GetTimestamp(); 
+    };
   std::set<LogType, decltype(log_comparison)> log_set(log_comparison);
   FileManagement::DataToken data_token;
   std::list<FileManagement::DataToken> data_tokens;
@@ -54,16 +65,6 @@ FileObject<LogCollection> LogFileManager::readBatch(
     actual_batch_size++;
     log_set.insert(input_event);
     data_tokens.push_back(data_token);
-  }
-
-  typedef std::chrono::high_resolution_clock Clock;
-  typedef std::chrono::hours hours;
-  Clock::time_point t0 = log_set.end().GetTimestamp();
-  Clock::time_point t1 = log_set.begin().GetTimestamp();
-  hours hrs = std::chrono::duration_cast<hrs>(t1 - t0);
-
-  if(hrs >= 24){
-    AWS_LOGSTREAM_ERROR(__func__, "The logs in this batch exceed a 24 hour time duration.");
   }
 
   LogCollection log_data(log_set.begin(), log_set.end());

--- a/cloudwatch_logs_common/src/utils/log_file_manager.cpp
+++ b/cloudwatch_logs_common/src/utils/log_file_manager.cpp
@@ -73,7 +73,6 @@ FileObject<LogCollection> LogFileManager::readBatch(
   std::set<LogType, decltype(log_comparison)> log_set(log_comparison);
   std::list<FileManagement::DataToken> data_tokens;
   size_t actual_batch_size = 0;
-  bool isOutdated = false;
   while(!pq.empty()){
     long curTime = std::get<0>(pq.top());
     std::string line = std::get<1>(pq.top());
@@ -86,16 +85,7 @@ FileObject<LogCollection> LogFileManager::readBatch(
       log_set.insert(input_event);
       data_tokens.push_back(new_data_token);
     }
-    else{
-      isOutdated = true;
-    }
-        pq.pop();
-  }
-
-  //notify user some logs are out of date and won't be store.
-  if(isOutdated){
-    AWS_LOG_INFO(__func__, 
-      "Some log files were out of date (> 24 hours time difference).");
+    pq.pop();
   }
 
   LogCollection log_data(log_set.begin(), log_set.end());

--- a/cloudwatch_logs_common/src/utils/log_file_manager.cpp
+++ b/cloudwatch_logs_common/src/utils/log_file_manager.cpp
@@ -45,10 +45,7 @@ FileObject<LogCollection> LogFileManager::readBatch(
 
   FileManagement::DataToken data_token;
   AWS_LOG_INFO(__func__, "Reading Logbatch");
-  
-  //go through the batch
-  //store the batch contents in a priority queue
-  //each element is a tuple with timestamp, line, data_token
+
   std::priority_queue<std::tuple<long, std::string, uint64_t>> pq;
   long latestTime = 0;
   for (size_t i = 0; i < batch_size; ++i) {
@@ -65,11 +62,7 @@ FileObject<LogCollection> LogFileManager::readBatch(
       latestTime = input_event.GetTimestamp();
     }
   }
-
-  //go through the priority queue
-  //ignore logs > 24 hours older than latest
-  //only count < 24 hours logs for acutal_batch-size
-  //build log_set and data_tokens using only new logs
+  
   std::set<LogType, decltype(log_comparison)> log_set(log_comparison);
   std::list<FileManagement::DataToken> data_tokens;
   size_t actual_batch_size = 0;
@@ -93,6 +86,7 @@ FileObject<LogCollection> LogFileManager::readBatch(
   file_object.batch_data = log_data;
   file_object.batch_size = actual_batch_size;
   file_object.data_tokens = data_tokens;
+  
   return file_object;
 }
 

--- a/cloudwatch_logs_common/src/utils/log_file_manager.cpp
+++ b/cloudwatch_logs_common/src/utils/log_file_manager.cpp
@@ -70,6 +70,13 @@ FileObject<LogCollection> LogFileManager::readBatch(
     AWS_LOGSTREAM_ERROR(__func__, "The logs in this batch exceed a 24 hour time duration.");
   }
 
+  //at this point log_set has been sorted
+  //by the log_comparison insertion sort
+
+  for(int i = 0; i < log_set.size(); i++){
+    cout << i << endl;
+  }
+
   LogCollection log_data(log_set.begin(), log_set.end());
   FileObject<LogCollection> file_object;
   file_object.batch_data = log_data;

--- a/cloudwatch_logs_common/src/utils/log_file_manager.cpp
+++ b/cloudwatch_logs_common/src/utils/log_file_manager.cpp
@@ -29,6 +29,16 @@ namespace Aws {
 namespace CloudWatchLogs {
 namespace Utils {
 
+//validate that the time between the oldest logand the newest log does not exceed 24 hours
+bool validateLogTime(const LogType & log1, const LogType & log2) {
+  //LogType.GetTimestamp returns time in milliseconds
+  //There are 86400000 milliseconds in 24 hours
+  if(log1.GetTimestamp() - log2.GetTimestamp() >= 86400000){
+    return false;
+  }
+  return true;
+}
+
 FileObject<LogCollection> LogFileManager::readBatch(
   size_t batch_size)
 {
@@ -66,16 +76,6 @@ FileObject<LogCollection> LogFileManager::readBatch(
   file_object.batch_size = actual_batch_size;
   file_object.data_tokens = data_tokens;
   return file_object;
-}
-
-//validate that the time between the oldest logand the newest log does not exceed 24 hours
-bool validateLogTime(const LogType & log1, const LogType & log2) {
-  //LogType.GetTimestamp returns time in milliseconds
-  //There are 86400000 milliseconds in 24 hours
-  if(log1.GetTimestamp() - log2.GetTimestamp() >= 86400000){
-    return false;
-  }
-  return true;
 }
 
 void LogFileManager::write(const LogCollection & data) {

--- a/cloudwatch_logs_common/src/utils/log_file_manager.cpp
+++ b/cloudwatch_logs_common/src/utils/log_file_manager.cpp
@@ -56,7 +56,7 @@ FileObject<LogCollection> LogFileManager::readBatch(
     data_tokens.push_back(data_token);
   }
 
-  if(*log_set.end().GetTimestamp() - *log_set.begin().GetTimestamp() >= 86400000){
+  if((*log_set.end()).GetTimestamp() - (*log_set.begin()).GetTimestamp() >= 86400000){
     AWS_LOGSTREAM_ERROR(__func__, "The logs in this batch exceed a 24 hour time duration.");
   }
 

--- a/cloudwatch_logs_common/src/utils/log_file_manager.cpp
+++ b/cloudwatch_logs_common/src/utils/log_file_manager.cpp
@@ -97,8 +97,8 @@ FileObject<LogCollection> LogFileManager::readBatch(
   }
 
   if(actual_batch_size != batch_size){
-    AWS_LOG_INFO(__func__, "Some logs were not read in this batch since the 
-      time difference was > 24 hours. Will try again in a separate batch.");
+    AWS_LOG_INFO(__func__, "Some logs were not read in this batch since the "
+      "time difference was > 24 hours. Will try again in a separate batch.");
   }
 
 

--- a/cloudwatch_logs_common/src/utils/log_file_manager.cpp
+++ b/cloudwatch_logs_common/src/utils/log_file_manager.cpp
@@ -28,7 +28,7 @@
 #include <aws/core/utils/logging/LogMacros.h>
 #include <cloudwatch_logs_common/definitions/definitions.h>
 
-#define 24HOURS 86400000
+#define HOURS24 86400000
 
 namespace Aws {
 namespace CloudWatchLogs {
@@ -70,7 +70,7 @@ FileObject<LogCollection> LogFileManager::readBatch(
     long curTime = std::get<0>(pq.top());
     std::string line = std::get<1>(pq.top());
     FileManagement::DataToken new_data_token = std::get<2>(pq.top());
-    if(latestTime - curTime < 24HOURS){
+    if(latestTime - curTime < HOURS24){
       Aws::String aws_line(line.c_str());
       Aws::Utils::Json::JsonValue value(aws_line);
       Aws::CloudWatchLogs::Model::InputLogEvent input_event(value);

--- a/cloudwatch_logs_common/src/utils/log_file_manager.cpp
+++ b/cloudwatch_logs_common/src/utils/log_file_manager.cpp
@@ -30,6 +30,7 @@ namespace CloudWatchLogs {
 namespace Utils {
 
 //validate that the time between the oldest logand the newest log does not exceed 24 hours
+/*
 bool validateLogTime(const LogType & log1, const LogType & log2) {
   //LogType.GetTimestamp returns time in milliseconds
   //There are 86400000 milliseconds in 24 hours
@@ -37,6 +38,19 @@ bool validateLogTime(const LogType & log1, const LogType & log2) {
     return false;
   }
   return true;
+}
+*/
+
+//validate that the time between the oldest logand the newest log does not exceed 24 hours
+void addValidData(std::set<LogType, decltype(log_comparison)> log_set) {
+  //save the latest time
+  //const LogType final = log_set.end();
+
+  //LogType.GetTimestamp returns time in milliseconds
+  //There are 86400000 milliseconds in 24 hours
+  for(std::set<LogType, decltype(log_comprison)>::iterator it = log_set->begin(); it != log_set.end(); ++it){
+    data_tokens.push_back(data_token);
+  }
 }
 
 FileObject<LogCollection> LogFileManager::readBatch(
@@ -63,19 +77,21 @@ FileObject<LogCollection> LogFileManager::readBatch(
     Aws::CloudWatchLogs::Model::InputLogEvent input_event(value);
     actual_batch_size++;
     log_set.insert(input_event);
-    data_tokens.push_back(data_token);
+
+    //move to addValidData
+    //data_tokens.push_back(data_token);
   }
 
+  /*
   if(!validateLogTime(*log_set.begin(), *log_set.end())){
     AWS_LOGSTREAM_ERROR(__func__, "The logs in this batch exceed a 24 hour time duration.");
   }
+  */
 
   //at this point log_set has been sorted
   //by the log_comparison insertion sort
 
-  for(int i = 0; i < log_set.size(); i++){
-    cout << i << endl;
-  }
+  addValidData(log_set);
 
   LogCollection log_data(log_set.begin(), log_set.end());
   FileObject<LogCollection> file_object;

--- a/cloudwatch_logs_common/src/utils/log_file_manager.cpp
+++ b/cloudwatch_logs_common/src/utils/log_file_manager.cpp
@@ -18,6 +18,7 @@
 #include <memory>
 #include <iostream>
 #include <fstream>
+#include <chrono>
 #include "cloudwatch_logs_common/utils/log_file_manager.h"
 #include "file_management/file_upload/file_manager_strategy.h"
 #include <aws/core/utils/json/JsonSerializer.h>
@@ -54,6 +55,17 @@ FileObject<LogCollection> LogFileManager::readBatch(
     log_set.insert(input_event);
     data_tokens.push_back(data_token);
   }
+
+  typedef std::chrono::high_resolution_clock Clock;
+  typedef std::chrono::hours hours;
+  Clock::time_point t0 = log_set.end().GetTimestamp();
+  Clock::time_point t1 = log_set.begin().GetTimestamp();
+  hours hrs = std::chrono::duration_cast<hrs>(t1 - t0);
+
+  if(hrs >= 24){
+    AWS_LOGSTREAM_ERROR(__func__, "The logs in this batch exceed a 24 hour time duration.");
+  }
+
   LogCollection log_data(log_set.begin(), log_set.end());
   FileObject<LogCollection> file_object;
   file_object.batch_data = log_data;

--- a/cloudwatch_logs_common/src/utils/log_file_manager.cpp
+++ b/cloudwatch_logs_common/src/utils/log_file_manager.cpp
@@ -60,7 +60,7 @@ FileObject<LogCollection> LogFileManager::readBatch(
   }
   
   long latestTime = std::get<0>(pq.top());
-  LogCollection log_data();
+  LogCollection log_data;
   std::list<FileManagement::DataToken> data_tokens;
   size_t actual_batch_size = 0;
   while(!pq.empty()){

--- a/cloudwatch_logs_common/src/utils/log_file_manager.cpp
+++ b/cloudwatch_logs_common/src/utils/log_file_manager.cpp
@@ -56,7 +56,7 @@ FileObject<LogCollection> LogFileManager::readBatch(
     data_tokens.push_back(data_token);
   }
 
-  if((*log_set.end()).GetTimestamp() - (*log_set.begin()).GetTimestamp() >= 86400000){
+  if(!validateLogTime(*log_set.begin(), *log_set.end())){
     AWS_LOGSTREAM_ERROR(__func__, "The logs in this batch exceed a 24 hour time duration.");
   }
 
@@ -66,6 +66,16 @@ FileObject<LogCollection> LogFileManager::readBatch(
   file_object.batch_size = actual_batch_size;
   file_object.data_tokens = data_tokens;
   return file_object;
+}
+
+//validate that the time between the oldest logand the newest log does not exceed 24 hours
+bool validateLogTime(const LogType & log1, const LogType & log2) {
+  //LogType.GetTimestamp returns time in milliseconds
+  //There are 86400000 milliseconds in 24 hours
+  if(log1.GetTimestamp() - log2.GetTimestamp() >= 86400000){
+    return false;
+  }
+  return true;
 }
 
 void LogFileManager::write(const LogCollection & data) {

--- a/cloudwatch_logs_common/src/utils/log_file_manager.cpp
+++ b/cloudwatch_logs_common/src/utils/log_file_manager.cpp
@@ -15,10 +15,9 @@
 
 
 
-#include <chrono>
 #include <fstream>
 #include <iostream>
-#include <memory>
+#include <memory>	
 #include <queue>
 #include <tuple>
 

--- a/cloudwatch_logs_common/src/utils/log_file_manager.cpp
+++ b/cloudwatch_logs_common/src/utils/log_file_manager.cpp
@@ -89,6 +89,7 @@ FileObject<LogCollection> LogFileManager::readBatch(
     else{
       isOutdated = true;
     }
+        pq.pop();
   }
 
   //notify user some logs are out of date and won't be store.

--- a/cloudwatch_logs_common/test/file_manager_test.cpp
+++ b/cloudwatch_logs_common/test/file_manager_test.cpp
@@ -29,6 +29,10 @@
 
 #include <file_management/file_upload/file_manager.h>
 #include <file_management/file_upload/file_manager_strategy.h>
+
+#include <cloudwatch_logs_common/log_service.h>
+#include <cloudwatch_logs_common/log_batcher.h>
+#include <cloudwatch_logs_common/log_publisher.h>
 #include <cloudwatch_logs_common/utils/log_file_manager.h>
 
 #include <dataflow_lite/utils/waiter.h>
@@ -36,7 +40,6 @@
 using Aws::CloudWatchLogs::Utils::LogFileManager;
 using namespace Aws::CloudWatchLogs;
 using namespace Aws::FileManagement;
-
 
 /**
  * Test the publisher interface while ignoring all of the CloudWatch specific infrastructure.

--- a/cloudwatch_logs_common/test/file_manager_test.cpp
+++ b/cloudwatch_logs_common/test/file_manager_test.cpp
@@ -171,19 +171,22 @@ public:
     };
 
     FileObject<LogCollection> readBatch(size_t batch_size) override {
-
       FileManagement::DataToken data_token;
+      //AWS_LOG_INFO(__func__, "Reading Logbatch");
+      std::cout << "Reading Logbatch" << std::endl;
       
       std::priority_queue<std::tuple<long, std::string, uint64_t>> pq;
       long latestTime = 0;
       std::list<std::string> lines;
-      lines.push_back("")
       for (size_t i = 0; i < batch_size; ++i) {
         std::string line;
         if (!file_manager_strategy_->isDataAvailable()) {
           break;
         }
-        data_token = read(line);
+        //data_token = read(line);
+        data_token = 0;
+        line = "test line #" + std::to_string(i);
+        std::cout << "Current Line Is: " + line << std::endl;
         Aws::String aws_line(line.c_str());
         Aws::Utils::Json::JsonValue value(aws_line);
         Aws::CloudWatchLogs::Model::InputLogEvent input_event(value);
@@ -214,7 +217,10 @@ public:
         }
       }
 
-      std::cout << "Some log files were out of date (> 24 hours time difference).";
+      if(isOutdated){
+        AWS_LOG_INFO(__func__, 
+          "Some log files were out of date (> 24 hours time difference).");
+      }
 
       LogCollection log_data(log_set.begin(), log_set.end());
       FileObject<LogCollection> file_object;

--- a/cloudwatch_logs_common/test/file_manager_test.cpp
+++ b/cloudwatch_logs_common/test/file_manager_test.cpp
@@ -230,9 +230,9 @@ TEST_F(FileManagerTest, file_manager_old_logs) {
   input_event.SetTimestamp(1);
   input_event.SetMessage("Slightly newer message");
   log_data.push_back(input_event);
-  file_manager.write(log_data);
+  file_manager->write(log_data);
   std::string line;
-  //file_manager.readBatch(1);
+  auto batch = file_manager->readBatch(1);
   //ASSERT_EQ(2u, batch.batch_data.size());
 }
 

--- a/cloudwatch_logs_common/test/file_manager_test.cpp
+++ b/cloudwatch_logs_common/test/file_manager_test.cpp
@@ -20,289 +20,42 @@
 
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
-
 #include <aws/logs/model/InputLogEvent.h>
-//#include <aws/core/Aws.h>
 #include <aws/core/utils/memory/stl/AWSString.h>
 #include <aws/core/utils/logging/ConsoleLogSystem.h>
 #include <aws/core/utils/logging/AWSLogging.h>
 
 #include <file_management/file_upload/file_manager.h>
-#include "file_management/file_upload/file_manager_strategy.h"
+#include <file_management/file_upload/file_manager_strategy.h>
+#include <file_management/utils/log_file_manager.h>
 
-#include <cloudwatch_logs_common/log_service.h>
-#include <cloudwatch_logs_common/log_batcher.h>
-#include <cloudwatch_logs_common/log_publisher.h>
-#include <cloudwatch_logs_common/utils/log_file_manager.h>
 
-#include <dataflow_lite/utils/waiter.h>
-
-#include <memory>
-#include <chrono>
-#include <queue>
-#include <tuple>
-#include <utility>      // std::pair, std::make_pair
-
-#include <aws/core/utils/json/JsonSerializer.h>
-#include <aws/core/utils/logging/LogMacros.h>
-#include <cloudwatch_logs_common/definitions/definitions.h>
-#include "file_management/file_upload/file_manager_strategy.h"
-
-using Aws::CloudWatchLogs::Utils::LogFileManager;
 using namespace Aws::CloudWatchLogs;
 using namespace Aws::FileManagement;
-
-/**
- * Test the publisher interface while ignoring all of the CloudWatch specific infrastructure.
- */
-class TestPublisher : public Publisher<std::list<Aws::CloudWatchLogs::Model::InputLogEvent>>, public Waiter
-{
-public:
-  TestPublisher() : Publisher() {
-    force_failure = false;
-    force_invalid_data_failure = false;
-    last_upload_status = Aws::DataFlow::UploadStatus::UNKNOWN;
-  };
-  ~TestPublisher() override = default;
-
-  bool start() override {
-    return Publisher::start();
-  }
-
-  // notify just in case anyone is waiting
-  bool shutdown() override {
-    bool is_shutdown = Publisher::shutdown();
-    this->notify(); //don't leave anyone blocking
-    return is_shutdown;
-  };
-
-  void setForceFailure(bool nv) {
-    force_failure = nv;
-  }
-
-  void setForceInvalidDataFailure(bool nv) {
-    force_invalid_data_failure = nv;
-  }
-
-  Aws::DataFlow::UploadStatus getLastUploadStatus() {
-    return last_upload_status;
-  }
-
-protected:
-
-  // override so we can notify when internal state changes, as attemptPublish sets state
-  Aws::DataFlow::UploadStatus attemptPublish(std::list<Aws::CloudWatchLogs::Model::InputLogEvent> &data) override {
-    last_upload_status = Publisher::attemptPublish(data);
-    {
-      this->notify();
-    }
-    return last_upload_status;
-  }
-
-  Aws::DataFlow::UploadStatus publishData(std::list<Aws::CloudWatchLogs::Model::InputLogEvent>&) override {
-
-    if (force_failure) {
-      return Aws::DataFlow::UploadStatus::FAIL;
-
-    } else if (force_invalid_data_failure) {
-      return Aws::DataFlow::UploadStatus::INVALID_DATA;
-
-    } else {
-      return Aws::DataFlow::UploadStatus::SUCCESS;
-    }
-  }
-
-  bool force_failure;
-  bool force_invalid_data_failure;
-  Aws::DataFlow::UploadStatus last_upload_status;
-};
 
 class FileManagerTest : public ::testing::Test {
 public:
   void SetUp() override
   {
-      test_publisher = std::make_shared<TestPublisher>();
-      batcher = std::make_shared<LogBatcher>();
-
-      //  log service owns the streamer, batcher, and publisher
-      cw_service = std::make_shared<LogService>(test_publisher, batcher);
-
-      stream_data_queue = std::make_shared<TaskObservedQueue<LogCollection>>();
-      queue_monitor = std::make_shared<Aws::DataFlow::QueueMonitor<TaskPtr<LogCollection>>>();
-
-      // create pipeline
-      batcher->setSink(stream_data_queue);
-      queue_monitor->addSource(stream_data_queue, Aws::DataFlow::PriorityOptions{Aws::DataFlow::HIGHEST_PRIORITY});
-      cw_service->setSource(queue_monitor);
-
-      cw_service->start(); //this starts the worker thread
-      EXPECT_EQ(Aws::DataFlow::UploadStatus::UNKNOWN, test_publisher->getLastUploadStatus());
   }
 
   void TearDown() override
   {
-      if (cw_service) {
-        cw_service->shutdown();
-        cw_service->join();
-      }
-    //std::experimental::filesystem::path storage_path(options.storage_directory);
-    //std::experimental::filesystem::remove_all(storage_path);
+    std::experimental::filesystem::path storage_path(options.storage_directory);
+    std::experimental::filesystem::remove_all(storage_path);
   }
 
 protected:
   FileManagerStrategyOptions options{"test", "log_tests/", ".log", 1024*1024, 1024*1024};
-
-  std::shared_ptr<TestPublisher> test_publisher;
-  std::shared_ptr<LogBatcher> batcher;
-  std::shared_ptr<LogService> cw_service;
-
-  std::shared_ptr<TaskObservedQueue<LogCollection>> stream_data_queue;
-  std::shared_ptr<Aws::DataFlow::QueueMonitor<TaskPtr<LogCollection>>>queue_monitor;
 };
-
-TEST_F(FileManagerTest, Sanity) {
-  ASSERT_TRUE(true);
-}
 
 /**
- * Test File Manager
+ * Test that the upload complete with CW Failure goes to a file.
  */
-class TestLogFileManager : public FileManager<LogCollection>, public Waiter
-{
-public:
-
-    TestLogFileManager() : FileManager(nullptr) {
-      written_count.store(0);
-    }
-
-    void write(const LogCollection & data) override {
-      last_data_size = data.size();
-      written_count++;
-      this->notify();
-    };
-
-    FileObject<LogCollection> readBatch(size_t batch_size) override {
-      //FileManagement::DataToken data_token;
-      //AWS_LOG_INFO(__func__, "Reading Logbatch");
-      std::cout << "Reading Logbatch" << std::endl;
-      
-      std::priority_queue<std::tuple<long, std::string, uint64_t>> pq;
-      long latestTime = 0;
-      std::list<std::string> lines;
-      for (size_t i = 0; i < batch_size; ++i) {
-        std::string line;
-        if (!file_manager_strategy_->isDataAvailable()) {
-          break;
-        }
-        //data_token = read(line);
-        line = "test line #" + std::to_string(i);
-        std::cout << "Current Line Is: " + line << std::endl;
-        Aws::String aws_line(line.c_str());
-        Aws::Utils::Json::JsonValue value(aws_line);
-        Aws::CloudWatchLogs::Model::InputLogEvent input_event(value);
-        pq.push(std::make_tuple(input_event.GetTimestamp(), line, 0));
-        if(input_event.GetTimestamp() > latestTime){
-          latestTime = input_event.GetTimestamp();
-        }
-      }
-
-      std::set<LogType, decltype(log_comparison)> log_set(log_comparison);
-      //std::list<FileManagement::DataToken> data_tokens;
-      size_t actual_batch_size = 0;
-      bool isOutdated = false;
-      while(!pq.empty()){
-        long curTime = std::get<0>(pq.top());
-        std::string line = std::get<1>(pq.top());
-        //FileManagement::DataToken new_data_token = std::get<2>(pq.top());
-        if(latestTime - curTime < 86400000){
-          Aws::String aws_line(line.c_str());
-          Aws::Utils::Json::JsonValue value(aws_line);
-          Aws::CloudWatchLogs::Model::InputLogEvent input_event(value);
-          actual_batch_size++;
-          log_set.insert(input_event);
-          //data_tokens.push_back(new_data_token);
-        }
-        else{
-          isOutdated = true;
-        }
-      }
-
-      if(isOutdated){
-        AWS_LOG_INFO(__func__, 
-          "Some log files were out of date (> 24 hours time difference).");
-      }
-
-      LogCollection log_data(log_set.begin(), log_set.end());
-      FileObject<LogCollection> file_object;
-      file_object.batch_data = log_data;
-      file_object.batch_size = actual_batch_size;
-      //file_object.data_tokens = data_tokens;
-      return file_object;
-    }
-
-    std::atomic<int> written_count{};
-    std::atomic<size_t> last_data_size{};
-    std::condition_variable cv;
-    mutable std::mutex mtx;
-};
-
-TEST_F(FileManagerTest, TestSinglePublisherFailureToFileManager) {
-
-  std::shared_ptr<TestLogFileManager> fileManager = std::make_shared<TestLogFileManager>();
-  // hookup to the service
-  batcher->setLogFileManager(fileManager);
-
-  // batch
-  std::string toBatch("TestBatcherManualPublish");
-  EXPECT_EQ(0u, batcher->getCurrentBatchSize());
-  bool is_batched = cw_service->batchData(toBatch);
-  EXPECT_EQ(1u, batcher->getCurrentBatchSize());
-  EXPECT_EQ(true, is_batched);
-
-  // force failure
-  test_publisher->setForceFailure(true);
-
-  // publish
-  bool b2 = cw_service->publishBatchedData();
-  test_publisher->wait_for(std::chrono::seconds(1));
-
-  EXPECT_TRUE(b2);
-  EXPECT_EQ(0u, batcher->getCurrentBatchSize());
-  EXPECT_EQ(PublisherState::NOT_CONNECTED, test_publisher->getPublisherState());
-  EXPECT_FALSE(cw_service->isConnected());
-  EXPECT_EQ(0, test_publisher->getPublishSuccesses());
-  EXPECT_EQ(1, test_publisher->getPublishAttempts());
-  EXPECT_EQ(0.0f, test_publisher->getPublishSuccessPercentage());
-
-  fileManager->wait_for(std::chrono::seconds(1));
-  //check that the filemanger callback worked
-  EXPECT_EQ(1, fileManager->written_count);
-  EXPECT_EQ(Aws::DataFlow::UploadStatus::FAIL, test_publisher->getLastUploadStatus());
-}
-
-//Test that logs in a batch separated by < 24 hours produce no error message
-
-TEST_F(FileManagerTest, file_manager_old_logs) {
-  std::shared_ptr<FileManagerStrategy> file_manager_strategy = std::make_shared<FileManagerStrategy>(options);
-  LogFileManager file_manager(file_manager_strategy);
-  LogCollection log_data;
-  Aws::CloudWatchLogs::Model::InputLogEvent input_event;
-  input_event.SetTimestamp(0);
-  input_event.SetMessage("Old message");
-  log_data.push_back(input_event);
-  input_event.SetTimestamp(1);
-  input_event.SetMessage("Slightly newer message");
-  log_data.push_back(input_event);
-  file_manager.write(log_data);
-  std::string line;
-  auto batch = file_manager.readBatch(1);
-  ASSERT_EQ(2u, batch.batch_data.size());
-}
-
 TEST_F(FileManagerTest, file_manager_write) {
   std::shared_ptr<FileManagerStrategy> file_manager_strategy = std::make_shared<FileManagerStrategy>(options);
   LogFileManager file_manager(file_manager_strategy);
-  LogCollection log_data;
+  LogEventCollection log_data;
   Aws::CloudWatchLogs::Model::InputLogEvent input_event;
   input_event.SetTimestamp(0);
   input_event.SetMessage("Hello my name is foo");
@@ -313,25 +66,14 @@ TEST_F(FileManagerTest, file_manager_write) {
   EXPECT_EQ(line, "{\"timestamp\":0,\"message\":\"Hello my name is foo\"}");
 }
 
-TEST_F(FileManagerTest, file_manager_old_logs_mock) {
-  std::shared_ptr<TestLogFileManager> fileManager = std::make_shared<TestLogFileManager>();
-  LogCollection log_data;
-  Aws::CloudWatchLogs::Model::InputLogEvent input_event;
-  input_event.SetTimestamp(0);
-  input_event.SetMessage("Old message");
-  log_data.push_back(input_event);
-  input_event.SetTimestamp(1);
-  input_event.SetMessage("Slightly newer message");
-  log_data.push_back(input_event);
-  fileManager->write(log_data);
-  std::string line;
-  auto batch = fileManager->readBatch(1);
-  ASSERT_EQ(2u, batch.batch_data.size());
-}
-
 int main(int argc, char** argv)
 {
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+  Aws::Utils::Logging::InitializeAWSLogging(
+      Aws::MakeShared<Aws::Utils::Logging::ConsoleLogSystem>(
+          "RunUnitTests", Aws::Utils::Logging::LogLevel::Trace));
+  ::testing::InitGoogleMock(&argc, argv);
+  int exitCode = RUN_ALL_TESTS();
+  Aws::Utils::Logging::ShutdownAWSLogging();
+  return exitCode;
 }
 

--- a/cloudwatch_logs_common/test/file_manager_test.cpp
+++ b/cloudwatch_logs_common/test/file_manager_test.cpp
@@ -230,9 +230,9 @@ TEST_F(FileManagerTest, file_manager_old_logs) {
   input_event.SetTimestamp(1);
   input_event.SetMessage("Slightly newer message");
   log_data.push_back(input_event);
-  file_manager->write(log_data);
+  file_manager.write(log_data);
   std::string line;
-  auto batch = file_manager->readBatch(1);
+  //auto batch = file_manager.readBatch(1);
   //ASSERT_EQ(2u, batch.batch_data.size());
 }
 

--- a/cloudwatch_logs_common/test/file_manager_test.cpp
+++ b/cloudwatch_logs_common/test/file_manager_test.cpp
@@ -66,6 +66,56 @@ TEST_F(FileManagerTest, file_manager_write) {
   EXPECT_EQ(line, "{\"timestamp\":0,\"message\":\"Hello my name is foo\"}");
 }
 
+/**
+ * Test that logs in a batch separated by < 24 hours produce no error message
+ */
+TEST_F(FileManagerTest, file_manager_old_logs) {
+  std::shared_ptr<FileManagerStrategy> file_manager_strategy = std::make_shared<FileManagerStrategy>(options);
+  LogFileManager file_manager(file_manager_strategy);
+  LogEventCollection log_data;
+  Aws::CloudWatchLogs::Model::InputLogEvent input_event;
+  input_event.SetTimestamp(0);
+  input_event.SetMessage("Old message");
+  log_data.push_back(input_event);
+  input_event.SetTimestamp(1);
+  input_event.SetMessage("Slightly newer message");
+  log_data.push_back(input_event);
+  file_manager.write(log_data);
+  std::string line;
+  file_manager.readBatch(2);
+  ASSERT_EQ(2u, batch.batch_data.size());
+  auto result = *batch.batch_data.begin();
+  EXPECT_EQ(input_event.GetCounts(), result.GetCounts());
+  EXPECT_EQ(input_event.GetMetricName(), result.GetMetricName());
+}
+
+/**
+ * Test that logs in a batch separated by > 24 hours produce error message
+ */
+TEST_F(FileManagerTest, file_manager_old_logs) {
+  std::shared_ptr<FileManagerStrategy> file_manager_strategy = std::make_shared<FileManagerStrategy>(options);
+  LogFileManager file_manager(file_manager_strategy);
+  LogEventCollection log_data;
+  Aws::CloudWatchLogs::Model::InputLogEvent input_event;
+  input_event.SetTimestamp(0);
+  input_event.SetMessage("Old message");
+  log_data.push_back(input_event);
+  input_event.SetTimestamp(1);
+  input_event.SetMessage("Slightly newer message");
+  log_data.push_back(input_event);
+  input_event.SetTimestamp(86400001);
+  input_event.SetMessage("New message");
+  log_data.push_back(input_event);
+  file_manager.write(log_data);
+  std::string line;
+  file_manager.readBatch(3);
+  file_manager_strategy->read(line);
+  ASSERT_EQ(2u, batch.batch_data.size());
+  auto result = *batch.batch_data.begin();
+  EXPECT_EQ(input_event.GetCounts(), result.GetCounts());
+  EXPECT_EQ(input_event.GetMetricName(), result.GetMetricName());
+}
+
 int main(int argc, char** argv)
 {
   Aws::Utils::Logging::InitializeAWSLogging(

--- a/cloudwatch_logs_common/test/file_manager_test.cpp
+++ b/cloudwatch_logs_common/test/file_manager_test.cpp
@@ -53,7 +53,7 @@ protected:
 
 //Test that logs in a batch separated by < 24 hours produce no error message
 
-TEST_F(FileManagerTestNew, file_manager_old_logs) {
+TEST_F(FileManagerTest, file_manager_old_logs) {
   std::shared_ptr<FileManagerStrategy> file_manager_strategy = std::make_shared<FileManagerStrategy>(options);
   LogFileManager file_manager(file_manager_strategy);
   LogCollection log_data;

--- a/cloudwatch_logs_common/test/file_manager_test.cpp
+++ b/cloudwatch_logs_common/test/file_manager_test.cpp
@@ -37,6 +37,16 @@
 
 #include <dataflow_lite/utils/waiter.h>
 
+#include <memory>
+#include <chrono>
+#include <queue>
+#include <tuple>
+#include <utility>      // std::pair, std::make_pair
+
+#include <aws/core/utils/json/JsonSerializer.h>
+#include <aws/core/utils/logging/LogMacros.h>
+#include <cloudwatch_logs_common/definitions/definitions.h>
+
 using Aws::CloudWatchLogs::Utils::LogFileManager;
 using namespace Aws::CloudWatchLogs;
 using namespace Aws::FileManagement;

--- a/cloudwatch_logs_common/test/log_batch_test.cpp
+++ b/cloudwatch_logs_common/test/log_batch_test.cpp
@@ -64,38 +64,14 @@ public:
 protected:
 };
 
-auto log_comparison = [](const LogType & log1, const LogType & log2)
-  { return log1.GetTimestamp() < log2.GetTimestamp(); };
-
-/**
- * Test File Manager
- */
-class TestLogFileManager : public FileManager<LogCollection>, public Waiter
-{
-public:
-
-    TestLogFileManager() : FileManager(nullptr) {
-      written_count.store(0);
-    }
-
-    void write(const LogCollection & data) override {
-      last_data_size = data.size();
-      written_count++;
-      this->notify();
-    };
-
-    std::atomic<int> written_count{};
-    std::atomic<size_t> last_data_size{};
-    std::condition_variable cv;
-    mutable std::mutex mtx;
-};
-
 class TestDataManagerStrategy : DataManagerStrategy, public Service {
 public:
-  DataManagerStrategy() = default;
-  ~DataManagerStrategy() override = default;
 
-  virtual DataToken read(std::string &data) = 0;
+  virtual DataToken read(std::string &data) override{
+    data = "test";
+    std::cout << "Testing: " + data << std ::endl;
+    return 0;
+  };
 };
 
 TEST_F(LogBatchTest, Sanity) {
@@ -106,7 +82,7 @@ TEST_F(LogBatchTest, Sanity) {
  * Expect one of them to be within 24 hour interval
  */
 TEST_F(LogBatchTest, batch_test_24hours) {
-  std::shared_ptr<TestLogFileManager> fileManager = std::make_shared<TestLogFileManager>();
+  std::shared_ptr<LogFileManager> fileManager = std::make_shared<LogFileManager>();
   auto batch = fileManager->readBatch(5);
   ASSERT_EQ(1u, batch.batch_size);
 }

--- a/cloudwatch_logs_common/test/log_batch_test.cpp
+++ b/cloudwatch_logs_common/test/log_batch_test.cpp
@@ -64,7 +64,7 @@ public:
 protected:
 };
 
-class TestDataManagerStrategy : DataManagerStrategy, public Service {
+class TestDataManagerStrategy : DataManagerStrategy {
 public:
 
   virtual DataToken read(std::string &data) override{

--- a/cloudwatch_logs_common/test/log_batch_test.cpp
+++ b/cloudwatch_logs_common/test/log_batch_test.cpp
@@ -13,38 +13,8 @@
  * permissions and limitations under the License.
  */
 
-#include <iostream>
-#include <fstream>
-#include <cstdio>
-#include <experimental/filesystem>
-
 #include <gtest/gtest.h>
-#include <gmock/gmock.h>
-
-#include <aws/logs/model/InputLogEvent.h>
-#include <aws/core/utils/memory/stl/AWSString.h>
-#include <aws/core/utils/logging/ConsoleLogSystem.h>
-#include <aws/core/utils/logging/AWSLogging.h>
-
-#include <file_management/file_upload/file_manager.h>
-#include "file_management/file_upload/file_manager_strategy.h"
-
-#include <cloudwatch_logs_common/log_service.h>
-#include <cloudwatch_logs_common/log_batcher.h>
-#include <cloudwatch_logs_common/log_publisher.h>
 #include <cloudwatch_logs_common/utils/log_file_manager.h>
-
-#include <dataflow_lite/utils/waiter.h>
-
-#include <chrono>
-#include <memory>
-#include <queue>
-#include <tuple>
-
-#include <aws/core/utils/json/JsonSerializer.h>
-#include <aws/core/utils/logging/LogMacros.h>
-#include <cloudwatch_logs_common/definitions/definitions.h>
-#include "file_management/file_upload/file_manager_strategy.h"
 
 using Aws::CloudWatchLogs::Utils::LogFileManager;
 using namespace Aws::CloudWatchLogs;

--- a/cloudwatch_logs_common/test/log_batch_test.cpp
+++ b/cloudwatch_logs_common/test/log_batch_test.cpp
@@ -180,11 +180,18 @@ public:
       this->notify();
     };
 
+    //test that the readBatch function works with 24 hour interval
     FileObject<LogCollection> readBatch(size_t batch_size) override {
       std::priority_queue<std::tuple<long, std::string, uint64_t>> pq;
       long latestTime = 0;
       for (size_t i = 0; i < batch_size; ++i) {
-        std::string line = "{\"timestamp\":" + std::to_string(i) + ",\"message\":\"Testing batch file\"}";
+        std::string line;
+        if(i == batch_size-1){
+            line =  = "{\"timestamp\":" + std::to_string(i + 86400000) + ",\"message\":\"Last log in batch file\"}";
+        }
+        else{
+            line =  = "{\"timestamp\":" + std::to_string(i) + ",\"message\":\"Testing batch file\"}";
+        }
         Aws::String aws_line(line.c_str());
         Aws::Utils::Json::JsonValue value(aws_line);
         Aws::CloudWatchLogs::Model::InputLogEvent input_event(value);
@@ -195,7 +202,6 @@ public:
       }
 
       std::set<LogType, decltype(log_comparison)> log_set(log_comparison);
-      //std::list<FileManagement::DataToken> data_tokens;
       size_t actual_batch_size = 0;
       while(!pq.empty()){
         long curTime = std::get<0>(pq.top());
@@ -227,10 +233,10 @@ TEST_F(LogBatchTest, Sanity) {
   ASSERT_TRUE(true);
 }
 
-TEST_F(LogBatchTest, file_manager_old_logs_mock) {
+TEST_F(LogBatchTest, batch_test_24hours) {
   std::shared_ptr<TestLogFileManager> fileManager = std::make_shared<TestLogFileManager>();
-  auto batch = fileManager->readBatch(2);
-  ASSERT_EQ(2u, batch.batch_size);
+  auto batch = fileManager->readBatch(5);
+  ASSERT_EQ(1u, batch.batch_size);
 }
 
 int main(int argc, char** argv)

--- a/cloudwatch_logs_common/test/log_batch_test.cpp
+++ b/cloudwatch_logs_common/test/log_batch_test.cpp
@@ -41,7 +41,6 @@
 #include <chrono>
 #include <queue>
 #include <tuple>
-#include <utility>      // std::pair, std::make_pair
 
 #include <aws/core/utils/json/JsonSerializer.h>
 #include <aws/core/utils/logging/LogMacros.h>

--- a/cloudwatch_logs_common/test/log_batch_test.cpp
+++ b/cloudwatch_logs_common/test/log_batch_test.cpp
@@ -181,14 +181,10 @@ public:
     };
 
     FileObject<LogCollection> readBatch(size_t batch_size) override {
-      std::cout << "Reading Logbatch" << std::endl;
-      
       std::priority_queue<std::tuple<long, std::string, uint64_t>> pq;
       long latestTime = 0;
-      std::list<std::string> lines;
       for (size_t i = 0; i < batch_size; ++i) {
-        std::string line;
-        line = "{\"timestamp\":0,\"message\":\"Testing batch file\"}" + std::to_string(i);
+        std::string line = "{\"timestamp\":" + std::to_string(i) + ",\"message\":\"Testing batch file\"}";
         Aws::String aws_line(line.c_str());
         Aws::Utils::Json::JsonValue value(aws_line);
         Aws::CloudWatchLogs::Model::InputLogEvent input_event(value);
@@ -201,7 +197,6 @@ public:
       std::set<LogType, decltype(log_comparison)> log_set(log_comparison);
       //std::list<FileManagement::DataToken> data_tokens;
       size_t actual_batch_size = 0;
-      bool isOutdated = false;
       while(!pq.empty()){
         long curTime = std::get<0>(pq.top());
         std::string line = std::get<1>(pq.top());

--- a/cloudwatch_logs_common/test/log_batch_test.cpp
+++ b/cloudwatch_logs_common/test/log_batch_test.cpp
@@ -186,10 +186,10 @@ public:
       for (size_t i = 0; i < batch_size; ++i) {
         std::string line;
         if(i == batch_size-1){
-            line =  = "{\"timestamp\":" + std::to_string(i + 86400000) + ",\"message\":\"Last log in batch file\"}";
+            line = "{\"timestamp\":" + std::to_string(i + 86400000) + ",\"message\":\"Last log in batch file\"}";
         }
         else{
-            line =  = "{\"timestamp\":" + std::to_string(i) + ",\"message\":\"Testing batch file\"}";
+            line = "{\"timestamp\":" + std::to_string(i) + ",\"message\":\"Testing batch file\"}";
         }
         Aws::String aws_line(line.c_str());
         Aws::Utils::Json::JsonValue value(aws_line);

--- a/cloudwatch_logs_common/test/log_batch_test.cpp
+++ b/cloudwatch_logs_common/test/log_batch_test.cpp
@@ -95,12 +95,14 @@ protected:
 /**
  * Test that the upload complete with CW Failure goes to a file.
  */
-TEST(3PASS) {
+TEST(log_batch_test, 3PASS) {
+  //use test_strategy to mock read/write functions from data_manager_strategy
   std::shared_ptr<TestStrategy> test_strategy = std::make_shared<TestStrategy>();
   LogFileManager file_manager(test_strategy);
-
   LogCollection log_data;
   Aws::CloudWatchLogs::Model::InputLogEvent input_event;
+
+  //add test data to logs
   input_event.SetTimestamp(0);
   input_event.SetMessage("Testing readBatch");
   log_data.push_back(input_event);
@@ -121,15 +123,30 @@ TEST(3PASS) {
   log_data.push_back(input_event);
   file_manager.write(log_data);
 
+  //read the batch
   auto batch = file_manager.readBatch(test_strategy->logs.size());
+
+  //only the latest logs should be included in batch
   ASSERT_EQ(3u, batch.batch_size);
+
+  //iterate through the logs in batch
+  auto it = batch.batch_data.begin();
+
+  //validate that they are the latest timestamps
+  ASSERT_EQ(ONE_DAY_IN_SEC, (*it).GetTimestamp());
+  it++;
+  ASSERT_EQ(ONE_DAY_IN_SEC+1, (*it).GetTimestamp());
+  it++;
+  ASSERT_EQ(ONE_DAY_IN_SEC+2, (*it).GetTimestamp());
 }
-TEST(ALLPASS) {
+TEST(log_batch_test, ALLPASS) {
+  //use test_strategy to mock read/write functions from data_manager_strategy
   std::shared_ptr<TestStrategy> test_strategy = std::make_shared<TestStrategy>();
   LogFileManager file_manager(test_strategy);
-
   LogCollection log_data;
   Aws::CloudWatchLogs::Model::InputLogEvent input_event;
+
+  //add test data to logs
   input_event.SetTimestamp(0);
   input_event.SetMessage("Testing readBatch");
   log_data.push_back(input_event);
@@ -150,15 +167,36 @@ TEST(ALLPASS) {
   log_data.push_back(input_event);
   file_manager.write(log_data);
 
+  //read the batch
   auto batch = file_manager.readBatch(test_strategy->logs.size());
+
+  //only the latest logs should be included in batch
   ASSERT_EQ(6u, batch.batch_size);
+
+  //iterate through the logs in batch
+  auto it = batch.batch_data.begin();
+
+  //validate that they are the latest timestamps
+  ASSERT_EQ(0, (*it).GetTimestamp());
+  it++;
+  ASSERT_EQ(1, (*it).GetTimestamp());
+  it++;
+  ASSERT_EQ(2, (*it).GetTimestamp());
+  it++;
+  ASSERT_EQ(3, (*it).GetTimestamp());
+  it++;
+  ASSERT_EQ(4, (*it).GetTimestamp());
+  it++;
+  ASSERT_EQ(ONE_DAY_IN_SEC-1, (*it).GetTimestamp());
 }
-TEST(ONEPASS) {
+TEST(log_batch_test, ONEPASS) {
+  //use test_strategy to mock read/write functions from data_manager_strategy
   std::shared_ptr<TestStrategy> test_strategy = std::make_shared<TestStrategy>();
   LogFileManager file_manager(test_strategy);
-
   LogCollection log_data;
   Aws::CloudWatchLogs::Model::InputLogEvent input_event;
+
+  //add test data to logs
   input_event.SetTimestamp(0);
   input_event.SetMessage("Testing readBatch");
   log_data.push_back(input_event);
@@ -179,8 +217,17 @@ TEST(ONEPASS) {
   log_data.push_back(input_event);
   file_manager.write(log_data);
 
+  //read the batch
   auto batch = file_manager.readBatch(test_strategy->logs.size());
+
+  //only the latest logs should be included in batch
   ASSERT_EQ(1u, batch.batch_size);
+
+  //iterate through the logs in batch
+  auto it = batch.batch_data.begin();
+
+  //validate that they are the latest timestamps
+  ASSERT_EQ(ONE_DAY_IN_SEC+5, (*it).GetTimestamp());
 }
 
 int main(int argc, char** argv)

--- a/cloudwatch_logs_common/test/log_batch_test.cpp
+++ b/cloudwatch_logs_common/test/log_batch_test.cpp
@@ -1,0 +1,305 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <iostream>
+#include <fstream>
+#include <cstdio>
+#include <experimental/filesystem>
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <aws/logs/model/InputLogEvent.h>
+//#include <aws/core/Aws.h>
+#include <aws/core/utils/memory/stl/AWSString.h>
+#include <aws/core/utils/logging/ConsoleLogSystem.h>
+#include <aws/core/utils/logging/AWSLogging.h>
+
+#include <file_management/file_upload/file_manager.h>
+#include "file_management/file_upload/file_manager_strategy.h"
+
+#include <cloudwatch_logs_common/log_service.h>
+#include <cloudwatch_logs_common/log_batcher.h>
+#include <cloudwatch_logs_common/log_publisher.h>
+#include <cloudwatch_logs_common/utils/log_file_manager.h>
+
+#include <dataflow_lite/utils/waiter.h>
+
+#include <memory>
+#include <chrono>
+#include <queue>
+#include <tuple>
+#include <utility>      // std::pair, std::make_pair
+
+#include <aws/core/utils/json/JsonSerializer.h>
+#include <aws/core/utils/logging/LogMacros.h>
+#include <cloudwatch_logs_common/definitions/definitions.h>
+#include "file_management/file_upload/file_manager_strategy.h"
+
+using Aws::CloudWatchLogs::Utils::LogFileManager;
+using namespace Aws::CloudWatchLogs;
+using namespace Aws::FileManagement;
+
+/**
+ * Test the publisher interface while ignoring all of the CloudWatch specific infrastructure.
+ */
+class TestPublisher : public Publisher<std::list<Aws::CloudWatchLogs::Model::InputLogEvent>>, public Waiter
+{
+public:
+  TestPublisher() : Publisher() {
+    force_failure = false;
+    force_invalid_data_failure = false;
+    last_upload_status = Aws::DataFlow::UploadStatus::UNKNOWN;
+  };
+  ~TestPublisher() override = default;
+
+  bool start() override {
+    return Publisher::start();
+  }
+
+  // notify just in case anyone is waiting
+  bool shutdown() override {
+    bool is_shutdown = Publisher::shutdown();
+    this->notify(); //don't leave anyone blocking
+    return is_shutdown;
+  };
+
+  void setForceFailure(bool nv) {
+    force_failure = nv;
+  }
+
+  void setForceInvalidDataFailure(bool nv) {
+    force_invalid_data_failure = nv;
+  }
+
+  Aws::DataFlow::UploadStatus getLastUploadStatus() {
+    return last_upload_status;
+  }
+
+protected:
+
+  // override so we can notify when internal state changes, as attemptPublish sets state
+  Aws::DataFlow::UploadStatus attemptPublish(std::list<Aws::CloudWatchLogs::Model::InputLogEvent> &data) override {
+    last_upload_status = Publisher::attemptPublish(data);
+    {
+      this->notify();
+    }
+    return last_upload_status;
+  }
+
+  Aws::DataFlow::UploadStatus publishData(std::list<Aws::CloudWatchLogs::Model::InputLogEvent>&) override {
+
+    if (force_failure) {
+      return Aws::DataFlow::UploadStatus::FAIL;
+
+    } else if (force_invalid_data_failure) {
+      return Aws::DataFlow::UploadStatus::INVALID_DATA;
+
+    } else {
+      return Aws::DataFlow::UploadStatus::SUCCESS;
+    }
+  }
+
+  bool force_failure;
+  bool force_invalid_data_failure;
+  Aws::DataFlow::UploadStatus last_upload_status;
+};
+
+class LogBatchTest : public ::testing::Test {
+public:
+  void SetUp() override
+  {
+      test_publisher = std::make_shared<TestPublisher>();
+      batcher = std::make_shared<LogBatcher>();
+
+      //  log service owns the streamer, batcher, and publisher
+      cw_service = std::make_shared<LogService>(test_publisher, batcher);
+
+      stream_data_queue = std::make_shared<TaskObservedQueue<LogCollection>>();
+      queue_monitor = std::make_shared<Aws::DataFlow::QueueMonitor<TaskPtr<LogCollection>>>();
+
+      // create pipeline
+      batcher->setSink(stream_data_queue);
+      queue_monitor->addSource(stream_data_queue, Aws::DataFlow::PriorityOptions{Aws::DataFlow::HIGHEST_PRIORITY});
+      cw_service->setSource(queue_monitor);
+
+      cw_service->start(); //this starts the worker thread
+      EXPECT_EQ(Aws::DataFlow::UploadStatus::UNKNOWN, test_publisher->getLastUploadStatus());
+  }
+
+  void TearDown() override
+  {
+      if (cw_service) {
+        cw_service->shutdown();
+        cw_service->join();
+      }
+    //std::experimental::filesystem::path storage_path(options.storage_directory);
+    //std::experimental::filesystem::remove_all(storage_path);
+  }
+
+protected:
+  FileManagerStrategyOptions options{"test", "log_tests/", ".log", 1024*1024, 1024*1024};
+
+  std::shared_ptr<TestPublisher> test_publisher;
+  std::shared_ptr<LogBatcher> batcher;
+  std::shared_ptr<LogService> cw_service;
+
+  std::shared_ptr<TaskObservedQueue<LogCollection>> stream_data_queue;
+  std::shared_ptr<Aws::DataFlow::QueueMonitor<TaskPtr<LogCollection>>>queue_monitor;
+};
+
+TEST_F(LogBatchTest, Sanity) {
+  ASSERT_TRUE(true);
+}
+
+/**
+ * Test File Manager
+ */
+class TestLogFileManager : public FileManager<LogCollection>, public Waiter
+{
+public:
+
+    TestLogFileManager() : FileManager(nullptr) {
+      written_count.store(0);
+    }
+
+    void write(const LogCollection & data) override {
+      last_data_size = data.size();
+      written_count++;
+      this->notify();
+    };
+
+    FileObject<LogCollection> readBatch(size_t batch_size) override {
+      //FileManagement::DataToken data_token;
+      //AWS_LOG_INFO(__func__, "Reading Logbatch");
+      std::cout << "Reading Logbatch" << std::endl;
+      
+      std::priority_queue<std::tuple<long, std::string, uint64_t>> pq;
+      long latestTime = 0;
+      std::list<std::string> lines;
+      for (size_t i = 0; i < batch_size; ++i) {
+        std::string line;
+        if (!file_manager_strategy_->isDataAvailable()) {
+          break;
+        }
+        //data_token = read(line);
+        line = "test line #" + std::to_string(i);
+        std::cout << "Current Line Is: " + line << std::endl;
+        Aws::String aws_line(line.c_str());
+        Aws::Utils::Json::JsonValue value(aws_line);
+        Aws::CloudWatchLogs::Model::InputLogEvent input_event(value);
+        pq.push(std::make_tuple(input_event.GetTimestamp(), line, 0));
+        if(input_event.GetTimestamp() > latestTime){
+          latestTime = input_event.GetTimestamp();
+        }
+      }
+
+      std::set<LogType, decltype(log_comparison)> log_set(log_comparison);
+      //std::list<FileManagement::DataToken> data_tokens;
+      size_t actual_batch_size = 0;
+      bool isOutdated = false;
+      while(!pq.empty()){
+        long curTime = std::get<0>(pq.top());
+        std::string line = std::get<1>(pq.top());
+        //FileManagement::DataToken new_data_token = std::get<2>(pq.top());
+        if(latestTime - curTime < 86400000){
+          Aws::String aws_line(line.c_str());
+          Aws::Utils::Json::JsonValue value(aws_line);
+          Aws::CloudWatchLogs::Model::InputLogEvent input_event(value);
+          actual_batch_size++;
+          log_set.insert(input_event);
+          //data_tokens.push_back(new_data_token);
+        }
+        else{
+          isOutdated = true;
+        }
+        pq.pop();
+      }
+
+      if(isOutdated){
+        AWS_LOG_INFO(__func__, 
+          "Some log files were out of date (> 24 hours time difference).");
+      }
+
+      LogCollection log_data(log_set.begin(), log_set.end());
+      FileObject<LogCollection> file_object;
+      file_object.batch_data = log_data;
+      file_object.batch_size = actual_batch_size;
+      //file_object.data_tokens = data_tokens;
+      std::cout << "Actual batch size is: " + std::to_string(actual_batch_size) << std::endl;
+      return file_object;
+    }
+
+    std::atomic<int> written_count{};
+    std::atomic<size_t> last_data_size{};
+    std::condition_variable cv;
+    mutable std::mutex mtx;
+};
+
+//Test that logs in a batch separated by < 24 hours produce no error message
+
+TEST_F(LogBatchTest, file_manager_old_logs) {
+  std::shared_ptr<FileManagerStrategy> file_manager_strategy = std::make_shared<FileManagerStrategy>(options);
+  LogFileManager file_manager(file_manager_strategy);
+  LogCollection log_data;
+  Aws::CloudWatchLogs::Model::InputLogEvent input_event;
+  input_event.SetTimestamp(0);
+  input_event.SetMessage("Old message");
+  log_data.push_back(input_event);
+  input_event.SetTimestamp(1);
+  input_event.SetMessage("Slightly newer message");
+  log_data.push_back(input_event);
+  file_manager.write(log_data);
+  std::string line;
+  auto batch = file_manager.readBatch(1);
+  ASSERT_EQ(2u, batch.batch_data.size());
+}
+
+TEST_F(LogBatchTest, file_manager_write) {
+  std::shared_ptr<FileManagerStrategy> file_manager_strategy = std::make_shared<FileManagerStrategy>(options);
+  LogFileManager file_manager(file_manager_strategy);
+  LogCollection log_data;
+  Aws::CloudWatchLogs::Model::InputLogEvent input_event;
+  input_event.SetTimestamp(0);
+  input_event.SetMessage("Hello my name is foo");
+  log_data.push_back(input_event);
+  file_manager.write(log_data);
+  std::string line;
+  file_manager_strategy->read(line);
+  EXPECT_EQ(line, "{\"timestamp\":0,\"message\":\"Hello my name is foo\"}");
+}
+
+TEST_F(LogBatchTest, file_manager_old_logs_mock) {
+  std::shared_ptr<TestLogFileManager> fileManager = std::make_shared<TestLogFileManager>();
+  LogCollection log_data;
+  Aws::CloudWatchLogs::Model::InputLogEvent input_event;
+  input_event.SetTimestamp(0);
+  input_event.SetMessage("Old message");
+  log_data.push_back(input_event);
+  input_event.SetTimestamp(1);
+  input_event.SetMessage("Slightly newer message");
+  log_data.push_back(input_event);
+  fileManager->write(log_data);
+  std::string line;
+  auto batch = fileManager->readBatch(1);
+  ASSERT_EQ(2u, batch.batch_data.size());
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+

--- a/cloudwatch_logs_common/test/log_batch_test.cpp
+++ b/cloudwatch_logs_common/test/log_batch_test.cpp
@@ -164,6 +164,9 @@ TEST_F(LogBatchTest, Sanity) {
   ASSERT_TRUE(true);
 }
 
+auto log_comparison = [](const LogType & log1, const LogType & log2)
+  { return log1.GetTimestamp() < log2.GetTimestamp(); };
+  
 /**
  * Test File Manager
  */
@@ -293,7 +296,7 @@ TEST_F(LogBatchTest, file_manager_old_logs_mock) {
   log_data.push_back(input_event);
   fileManager->write(log_data);
   std::string line;
-  auto batch = fileManager->readBatch(1);
+  auto batch = fileManager->readBatch(2);
   ASSERT_EQ(2u, batch.batch_data.size());
 }
 

--- a/cloudwatch_logs_common/test/log_batch_test.cpp
+++ b/cloudwatch_logs_common/test/log_batch_test.cpp
@@ -52,20 +52,6 @@ using namespace Aws::FileManagement;
 
 const long ONE_DAY_IN_SEC = 86400000;
 
-class LogBatchTest : public ::testing::Test {
-public:
-  void SetUp() override
-  {
-  }
-
-  void TearDown() override
-  {
-  }
-
-protected:
-  FileManagerStrategyOptions options{"test", "log_tests/", ".log", 1024*1024, 1024*1024};
-};
-
 class TestStrategy : public DataManagerStrategy {
 public:
   bool isDataAvailable(){
@@ -109,7 +95,7 @@ protected:
 /**
  * Test that the upload complete with CW Failure goes to a file.
  */
-TEST_F(LogBatchTest, 3PASS) {
+TEST(3PASS) {
   std::shared_ptr<TestStrategy> test_strategy = std::make_shared<TestStrategy>();
   LogFileManager file_manager(test_strategy);
 
@@ -138,7 +124,7 @@ TEST_F(LogBatchTest, 3PASS) {
   auto batch = file_manager.readBatch(test_strategy->logs.size());
   ASSERT_EQ(3u, batch.batch_size);
 }
-TEST_F(LogBatchTest, ALLPASS) {
+TEST(ALLPASS) {
   std::shared_ptr<TestStrategy> test_strategy = std::make_shared<TestStrategy>();
   LogFileManager file_manager(test_strategy);
 
@@ -167,7 +153,7 @@ TEST_F(LogBatchTest, ALLPASS) {
   auto batch = file_manager.readBatch(test_strategy->logs.size());
   ASSERT_EQ(6u, batch.batch_size);
 }
-TEST_F(LogBatchTest, ONEPASS) {
+TEST(ONEPASS) {
   std::shared_ptr<TestStrategy> test_strategy = std::make_shared<TestStrategy>();
   LogFileManager file_manager(test_strategy);
 
@@ -179,7 +165,7 @@ TEST_F(LogBatchTest, ONEPASS) {
   input_event.SetTimestamp(1);
   input_event.SetMessage("Testing readBatch");
   log_data.push_back(input_event);
-  input_event.SetTimestamp(ONE_DAY_IN_SEC-5);
+  input_event.SetTimestamp(ONE_DAY_IN_SEC+5);
   input_event.SetMessage("Testing readBatch");
   log_data.push_back(input_event);
   input_event.SetTimestamp(2);

--- a/cloudwatch_logs_common/test/log_batch_test.cpp
+++ b/cloudwatch_logs_common/test/log_batch_test.cpp
@@ -62,21 +62,27 @@ protected:
   FileManagerStrategyOptions options_;
 };
 
+class LogBatchTest{
+protected:
+  void SetUp() override {
+    //use test_strategy to mock read/write functions from data_manager_strategy
+    std::shared_ptr<TestStrategy> test_strategy = std::make_shared<TestStrategy>();
+    LogFileManager file_manager(test_strategy);
+    LogCollection log_data;
+    Aws::CloudWatchLogs::Model::InputLogEvent input_event;
+  }
+  
+  void TearDown() override {
+    
+  }
+};
+
 /**
  * Test that the upload complete with CW Failure goes to a file.
  */
-TEST(log_batch_test, 3PASS) {
-  //use test_strategy to mock read/write functions from data_manager_strategy
-  std::shared_ptr<TestStrategy> test_strategy = std::make_shared<TestStrategy>();
-  LogFileManager file_manager(test_strategy);
-  LogCollection log_data;
-  Aws::CloudWatchLogs::Model::InputLogEvent input_event;
-
+TEST_F(LogBatchTest, test_readBatch_3_of_6_pass) {
   //add test data to logs
-  input_event.SetTimestamp(0);
-  input_event.SetMessage("Testing readBatch");
-  log_data.push_back(input_event);
-  input_event.SetTimestamp(1);
+  input_event.SetTimestamp(ONE_DAY_IN_SEC+1);
   input_event.SetMessage("Testing readBatch");
   log_data.push_back(input_event);
   input_event.SetTimestamp(2);
@@ -85,7 +91,10 @@ TEST(log_batch_test, 3PASS) {
   input_event.SetTimestamp(ONE_DAY_IN_SEC+2);
   input_event.SetMessage("Testing readBatch");
   log_data.push_back(input_event);
-  input_event.SetTimestamp(ONE_DAY_IN_SEC+1);
+  input_event.SetTimestamp(1);
+  input_event.SetMessage("Testing readBatch");
+  log_data.push_back(input_event);
+  input_event.SetTimestamp(0);
   input_event.SetMessage("Testing readBatch");
   log_data.push_back(input_event);
   input_event.SetTimestamp(ONE_DAY_IN_SEC);
@@ -109,27 +118,21 @@ TEST(log_batch_test, 3PASS) {
   it++;
   ASSERT_EQ(ONE_DAY_IN_SEC+2, (*it).GetTimestamp());
 }
-TEST(log_batch_test, ALLPASS) {
-  //use test_strategy to mock read/write functions from data_manager_strategy
-  std::shared_ptr<TestStrategy> test_strategy = std::make_shared<TestStrategy>();
-  LogFileManager file_manager(test_strategy);
-  LogCollection log_data;
-  Aws::CloudWatchLogs::Model::InputLogEvent input_event;
-
+TEST_F(LogBatchTest, test_readBatch_6_of_6_pass) {
   //add test data to logs
-  input_event.SetTimestamp(0);
-  input_event.SetMessage("Testing readBatch");
-  log_data.push_back(input_event);
   input_event.SetTimestamp(1);
-  input_event.SetMessage("Testing readBatch");
-  log_data.push_back(input_event);
-  input_event.SetTimestamp(2);
   input_event.SetMessage("Testing readBatch");
   log_data.push_back(input_event);
   input_event.SetTimestamp(3);
   input_event.SetMessage("Testing readBatch");
   log_data.push_back(input_event);
+  input_event.SetTimestamp(0);
+  input_event.SetMessage("Testing readBatch");
+  log_data.push_back(input_event);
   input_event.SetTimestamp(4);
+  input_event.SetMessage("Testing readBatch");
+  log_data.push_back(input_event);
+  input_event.SetTimestamp(2);
   input_event.SetMessage("Testing readBatch");
   log_data.push_back(input_event);
   input_event.SetTimestamp(ONE_DAY_IN_SEC-1);
@@ -159,30 +162,24 @@ TEST(log_batch_test, ALLPASS) {
   it++;
   ASSERT_EQ(ONE_DAY_IN_SEC-1, (*it).GetTimestamp());
 }
-TEST(log_batch_test, ONEPASS) {
-  //use test_strategy to mock read/write functions from data_manager_strategy
-  std::shared_ptr<TestStrategy> test_strategy = std::make_shared<TestStrategy>();
-  LogFileManager file_manager(test_strategy);
-  LogCollection log_data;
-  Aws::CloudWatchLogs::Model::InputLogEvent input_event;
-
+TEST_F(LogBatchTest, test_readBatch_1_of_6_pass) {
   //add test data to logs
-  input_event.SetTimestamp(0);
-  input_event.SetMessage("Testing readBatch");
-  log_data.push_back(input_event);
   input_event.SetTimestamp(1);
   input_event.SetMessage("Testing readBatch");
   log_data.push_back(input_event);
   input_event.SetTimestamp(ONE_DAY_IN_SEC+5);
   input_event.SetMessage("Testing readBatch");
   log_data.push_back(input_event);
+  input_event.SetTimestamp(4);
+  input_event.SetMessage("Testing readBatch");
+  log_data.push_back(input_event);
   input_event.SetTimestamp(2);
   input_event.SetMessage("Testing readBatch");
   log_data.push_back(input_event);
-  input_event.SetTimestamp(3);
+  input_event.SetTimestamp(0);
   input_event.SetMessage("Testing readBatch");
   log_data.push_back(input_event);
-  input_event.SetTimestamp(4);
+  input_event.SetTimestamp(3);
   input_event.SetMessage("Testing readBatch");
   log_data.push_back(input_event);
   file_manager.write(log_data);

--- a/cloudwatch_logs_common/test/log_batch_test.cpp
+++ b/cloudwatch_logs_common/test/log_batch_test.cpp
@@ -260,7 +260,7 @@ TEST_F(LogBatchTest, Sanity) {
 TEST_F(LogBatchTest, file_manager_write) {
   std::shared_ptr<FileManagerStrategy> file_manager_strategy = std::make_shared<FileManagerStrategy>(options);
   LogFileManager file_manager(file_manager_strategy);
-  LogEventCollection log_data;
+  LogCollection log_data;
   Aws::CloudWatchLogs::Model::InputLogEvent input_event;
   input_event.SetTimestamp(0);
   input_event.SetMessage("Hello my name is foo");
@@ -274,20 +274,6 @@ TEST_F(LogBatchTest, file_manager_write) {
 /**
  * Test that logs in a batch separated by < 24 hours produce no error message
  */
-TEST_F(LogBatchTest, file_manager_write) {
-  std::shared_ptr<FileManagerStrategy> file_manager_strategy = std::make_shared<FileManagerStrategy>(options);
-  LogFileManager file_manager(file_manager_strategy);
-  LogEventCollection log_data;
-  Aws::CloudWatchLogs::Model::InputLogEvent input_event;
-  input_event.SetTimestamp(0);
-  input_event.SetMessage("Hello my name is foo");
-  log_data.push_back(input_event);
-  file_manager.write(log_data);
-  std::string line;
-  //file_manager_strategy->read(line);
-  //EXPECT_EQ(line, "{\"timestamp\":0,\"message\":\"Hello my name is foo\"}");
-}
-
 TEST_F(LogBatchTest, file_manager_old_logs) {
   std::shared_ptr<FileManagerStrategy> file_manager_strategy = std::make_shared<FileManagerStrategy>(options);
   LogFileManager file_manager(file_manager_strategy);


### PR DESCRIPTION
Closes #53 

Prevent cloudwatch logs with over 24 hours of time difference from being batched together in the readBatch function.

Signed-off-by: Jesse Ikawa <jikawa@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
