### PR TITLE
Allow user to automatically delete CloudWatch logs in batch that are > 14 days old

### DIFF
--- a/cloudwatch_logs_common/include/cloudwatch_logs_common/utils/log_file_manager.h
+++ b/cloudwatch_logs_common/include/cloudwatch_logs_common/utils/log_file_manager.h
@@ -59,7 +59,9 @@ class LogFileManager :
     return as many logs as can fit within the 24 hour span and the actual number of 
     logs batched may end up being less than the original batch_size.
 
-    If a log is over 2 weeks old from the latest time,it will be discarded.
+    If the user cfg options for discard_old_logs and a log is over 2 weeks old from
+    the latest time,it will be discarded. This is because the AWS API for PutLogEvents
+    rejects batches with log events older than 14 days.
 
     We must sort the log data chronologically because it is not guaranteed
     to be ordered chronologically in the file, but CloudWatch requires all

--- a/cloudwatch_logs_common/include/cloudwatch_logs_common/utils/log_file_manager.h
+++ b/cloudwatch_logs_common/include/cloudwatch_logs_common/utils/log_file_manager.h
@@ -53,6 +53,18 @@ class LogFileManager :
 
   void write(const LogCollection & data) override;
 
+  /*  
+    AWSClient will return 'InvalidParameterException' error when the log events in a
+    single batch span more than 24 hours. Therefore the readBatch function will only
+    return as many logs as can fit within the 24 hour span and the actual number of 
+    logs batched may end up being less than the original batch_size.
+
+    If a log is over 2 weeks old from the latest time,it will be discarded.
+
+    We must sort the log data chronologically because it is not guaranteed
+    to be ordered chronologically in the file, but CloudWatch requires all
+    puts in a single batch to be sorted chronologically
+  */
   FileObject<LogCollection> readBatch(size_t batch_size) override;
 };
 

--- a/cloudwatch_logs_common/include/cloudwatch_logs_common/utils/log_file_manager.h
+++ b/cloudwatch_logs_common/include/cloudwatch_logs_common/utils/log_file_manager.h
@@ -67,16 +67,8 @@ class LogFileManager :
   */
   FileObject<LogCollection> readBatch(size_t batch_size) override;
 
-  /*
-    If the user cfg options for discard_old_logs and a log is over 2 weeks old from
-    the latest time,it will be discarded. This is because the AWS API for PutLogEvents
-    rejects batches with log events older than 14 days.
-  */
-  void discardFiles() override;
-
   using Timestamp = long;
   Timestamp latestTime = 0;
-  std::priority_queue<std::tuple<Timestamp, std::string, FileManagement::DataToken>> pq;
 };
 
 }  // namespace Utils

--- a/cloudwatch_logs_common/test/log_batch_test.cpp
+++ b/cloudwatch_logs_common/test/log_batch_test.cpp
@@ -21,51 +21,62 @@ using namespace Aws::CloudWatchLogs;
 using namespace Aws::FileManagement;
 
 const long ONE_DAY_IN_SEC = 86400000;
+const long TWO_WEEK_IN_SEC = 1209600000;
 
 class TestStrategy : public DataManagerStrategy {
 public:
+  TestStrategy(const FileManagerStrategyOptions &options) {
+    options_ = options;
+  }
+
   bool isDataAvailable(){
-    return true;
+    return !logs.empty() && !data_tokens.empty();
+  }
+
+  bool discardOldLogs(){
+    return options_.discard_2_week_logs;
   }
 
   DataToken read(std::string &data) override{
-    if(!logs.empty()){
-        data = logs.back();
-        logs.pop_back();
+    if(isDataAvailable()){
+      it++;
+      data = logs[it-1];
+      return data_tokens[it-1];
     }
 
-    data_token++;
-    return data_token;
+    return 0;
   }
 
   void write(const std::string &data){
       logs.push_back(data);
+      data_tokens.push_back(data_token);
+      data_token++;
   }
 
   void resolve(const DataToken &token, bool is_success){
-    if(is_success && token)
-        return;
-    else
-        return;
+    if(is_success){
+      for(int i = 0; i < (int)data_tokens.size(); i++){
+        if(data_tokens[i] == token){
+          data_tokens.erase(data_tokens.begin()+i);
+          logs.erase(logs.begin()+i);
+          return;
+        }
+      }
+    }
     return;
   }
 
   std::vector<std::string> logs;
-
-protected:
-
-  uint64_t data_token = 0;
-
-  /**
-   * Options for how and where to store files, and maximum file sizes.
-   */
+  std::vector<uint64_t> data_tokens;
+  uint64_t data_token = 1;
+  int it = 0;
   FileManagerStrategyOptions options_;
 };
 
 class LogBatchTest : public ::testing::Test{
 public:
   void SetUp() override {
-    test_strategy = std::make_shared<TestStrategy>();
+    test_strategy = std::make_shared<TestStrategy>(options);
     file_manager = std::make_unique<LogFileManager>(test_strategy);
   }
 
@@ -82,52 +93,103 @@ public:
     }
   }
 
-  void validateBatch(const std::vector<long> & timestamps){
-    auto it = batch.batch_data.begin();
-    for (auto ts : timestamps){
-        ASSERT_EQ(ts, (*it).GetTimestamp());
-        it++;
+  void readLogs(){
+    while(test_strategy->isDataAvailable()){
+      test_strategy->it = 0;
+      batch = file_manager->readBatch(test_strategy->logs.size());
+      resolveBatch();
+      ASSERT_TRUE(validateBatch());
     }
   }
 
-  //use test_strategy to mock read/write functions from data_manager_strategy
+  void resolveBatch(){
+    for (auto dt : batch.data_tokens){
+      test_strategy->resolve(dt, true);
+    }
+  }
+
+  //validate that the batch produced matches with the user's expectation
+  bool validateBatch(){
+    for(auto bd : batch.batch_data){
+      if(expectedTimeStamps.empty())
+        return false;
+
+      long expectedTimestamp = expectedTimeStamps.front().back();
+      expectedTimeStamps.front().pop_back();
+
+      if(expectedTimeStamps.front().empty())
+        expectedTimeStamps.erase(expectedTimeStamps.begin());
+
+      if(bd.GetTimestamp() != expectedTimestamp){
+        return false;
+      }
+    }
+
+    return true;
+  }
+
   std::shared_ptr<TestStrategy> test_strategy;
   std::unique_ptr<LogFileManager> file_manager;
   LogCollection log_data;
   Aws::CloudWatchLogs::Model::InputLogEvent input_event;
   std::vector<long> timestamps;
   FileObject<LogCollection> batch;
+  FileManagerStrategyOptions options{"test", "log_tests/", ".log", 1024*1024, 1024*1024, true};
+  std::vector<std::vector<long>> expectedTimeStamps;
 };
 
 /**
  * Test that the upload complete with CW Failure goes to a file.
  */
-TEST_F(LogBatchTest, test_readBatch_3_of_6_pass) {
-  timestamps = {ONE_DAY_IN_SEC+1, 2, ONE_DAY_IN_SEC+2, 1, 0, ONE_DAY_IN_SEC};
-  createLogs(timestamps);
-  file_manager->write(log_data);
-  batch = file_manager->readBatch(test_strategy->logs.size());
-  ASSERT_EQ(3u, batch.batch_size);
-  timestamps = {ONE_DAY_IN_SEC, ONE_DAY_IN_SEC+1, ONE_DAY_IN_SEC+2};
-  validateBatch(timestamps);
-}
-TEST_F(LogBatchTest, test_readBatch_6_of_6_pass) {
+TEST_F(LogBatchTest, test_readBatch_1_batch) {
   timestamps = {1, 3, 0, ONE_DAY_IN_SEC-1, 4, 2};
+  expectedTimeStamps = {{ONE_DAY_IN_SEC-1, 4, 3, 2, 1, 0}};
   createLogs(timestamps);
   file_manager->write(log_data);
-  batch = file_manager->readBatch(test_strategy->logs.size());
-  ASSERT_EQ(6u, batch.batch_size);
-  timestamps = {0, 1, 2, 3, 4, ONE_DAY_IN_SEC-1};
-  validateBatch(timestamps);
+  readLogs();
 }
-TEST_F(LogBatchTest, test_readBatch_1_of_6_pass) {
-  timestamps = {1, ONE_DAY_IN_SEC+5, 4, 2, 0, 3};
+TEST_F(LogBatchTest, test_readBatch_2_batches) {
+  timestamps = {ONE_DAY_IN_SEC+1, 2, ONE_DAY_IN_SEC+2, 1, 0, ONE_DAY_IN_SEC};
+  expectedTimeStamps = {{ONE_DAY_IN_SEC+2, ONE_DAY_IN_SEC+1, ONE_DAY_IN_SEC}, {2, 1, 0}};
   createLogs(timestamps);
   file_manager->write(log_data);
-  batch = file_manager->readBatch(test_strategy->logs.size());
-  ASSERT_EQ(1u, batch.batch_size);
-  timestamps = {ONE_DAY_IN_SEC+5};
-  validateBatch(timestamps);
+  readLogs();
+}
+TEST_F(LogBatchTest, test_readBatch_3_batches) {
+  timestamps = {1, ONE_DAY_IN_SEC+5, 4, 2, 0, ONE_DAY_IN_SEC*2+10};
+  expectedTimeStamps = {{ONE_DAY_IN_SEC*2+10}, {ONE_DAY_IN_SEC+5},{4, 2, 1, 0}};
+  createLogs(timestamps);
+  file_manager->write(log_data);
+  readLogs();
+}
+TEST_F(LogBatchTest, test_2_week_discard_1_of_6) {
+  timestamps = {15, ONE_DAY_IN_SEC, 0, TWO_WEEK_IN_SEC+5, TWO_WEEK_IN_SEC+1, 10};
+  expectedTimeStamps = {{TWO_WEEK_IN_SEC+5, TWO_WEEK_IN_SEC+1}, {ONE_DAY_IN_SEC, 15, 10}};
+  createLogs(timestamps);
+  file_manager->write(log_data);
+  readLogs();
+}
+TEST_F(LogBatchTest, test_2_week_discard_4_of_6) {
+  timestamps = {1, ONE_DAY_IN_SEC, 4, TWO_WEEK_IN_SEC+5, 0, 3};
+  expectedTimeStamps = {{TWO_WEEK_IN_SEC+5}, {ONE_DAY_IN_SEC}};
+  createLogs(timestamps);
+  file_manager->write(log_data);
+  readLogs();
+}
+TEST_F(LogBatchTest, test_2_week_discard_5_of_6) {
+  timestamps = {1, ONE_DAY_IN_SEC, 4, TWO_WEEK_IN_SEC+ONE_DAY_IN_SEC+5, 0, 3};
+  expectedTimeStamps = {{TWO_WEEK_IN_SEC+ONE_DAY_IN_SEC+5}};
+  createLogs(timestamps);
+  file_manager->write(log_data);
+  readLogs();
+}
+TEST_F(LogBatchTest, test_2_week_no_discard) {
+  test_strategy->options_.discard_2_week_logs = false;
+  timestamps = {1, ONE_DAY_IN_SEC, 4, TWO_WEEK_IN_SEC+5, 0, 3};
+  expectedTimeStamps = {{TWO_WEEK_IN_SEC+5},{ONE_DAY_IN_SEC, 4, 3, 1}, {0}};
+  createLogs(timestamps);
+  file_manager->write(log_data);
+  readLogs();
 }
 
 int main(int argc, char** argv)

--- a/cloudwatch_logs_common/test/log_batch_test.cpp
+++ b/cloudwatch_logs_common/test/log_batch_test.cpp
@@ -34,10 +34,6 @@ public:
     return options_.delete_stale_data;
   }
 
-  void setDeleteStaleData(bool set_stale_data) {
-    options_.delete_stale_data = set_stale_data;
-  }
-
   DataToken read(std::string &data) override{
     if(isDataAvailable()){
       it++;
@@ -233,28 +229,24 @@ TEST_F(LogBatchTest, test_2_week_no_delete) {
   readLogs();
 }
 /**
- * FileManagerStrategyOptions defined with delete_stale_data originally
- * initialized to true, then set to false.
+ * FileManagerStrategyOptions defined with delete_stale_data set to true.
+ * We expect isDeleteStaleData to return true.
  */
 TEST(DeleteOptionTest, file_manager_delete_true) {
   FileManagerStrategyOptions options{"test", "log_tests/", ".log", 1024*1024, 1024*1024, true};
   std::shared_ptr<FileManagerStrategy> file_manager_strategy = std::make_shared<FileManagerStrategy>(options);
   LogFileManager file_manager(file_manager_strategy);
   ASSERT_TRUE(file_manager_strategy->isDeleteStaleData());
-  file_manager_strategy->setDeleteStaleData(false);
-  ASSERT_FALSE(file_manager_strategy->isDeleteStaleData());
 }
 /**
- * FileManagerStrategyOptions defined with delete_stale_data originally
- * initialized to false, then set to true.
+ * FileManagerStrategyOptions defined with delete_stale_data set to false.
+ * We expect isDeleteStaleData to return false.
  */
 TEST(DeleteOptionTest, file_manager_delete_false) {
   FileManagerStrategyOptions options{"test", "log_tests/", ".log", 1024*1024, 1024*1024, false};
   std::shared_ptr<FileManagerStrategy> file_manager_strategy = std::make_shared<FileManagerStrategy>(options);
   LogFileManager file_manager(file_manager_strategy);
   ASSERT_FALSE(file_manager_strategy->isDeleteStaleData());
-  file_manager_strategy->setDeleteStaleData(true);
-  ASSERT_TRUE(file_manager_strategy->isDeleteStaleData());
 }
 
 int main(int argc, char** argv)

--- a/cloudwatch_metrics_common/include/cloudwatch_metrics_common/cloudwatch_options.h
+++ b/cloudwatch_metrics_common/include/cloudwatch_metrics_common/cloudwatch_options.h
@@ -40,7 +40,8 @@ static const Aws::FileManagement::FileManagerStrategyOptions kDefaultMetricFileM
   "cwmetric",
   Aws::FileManagement::kDefaultFileManagerStrategyOptions.file_extension,
   Aws::FileManagement::kDefaultFileManagerStrategyOptions.maximum_file_size_in_kb,
-  Aws::FileManagement::kDefaultFileManagerStrategyOptions.storage_limit_in_kb
+  Aws::FileManagement::kDefaultFileManagerStrategyOptions.storage_limit_in_kb,
+  Aws::FileManagement::kDefaultFileManagerStrategyOptions.delete_stale_data
 };
 
 static const CloudWatchOptions kDefaultCloudWatchOptions{

--- a/file_management/include/file_management/file_manager_options.h
+++ b/file_management/include/file_management/file_manager_options.h
@@ -36,13 +36,13 @@ struct FileManagerStrategyOptions {
     std::string _file_extension,
     size_t _maximum_file_size,
     size_t _storage_limit,
-    bool _discard_2_week_logs = false)
+    bool _discard_old_logs = false)
     : storage_directory(std::move(_storage_directory)),
       file_prefix(std::move(_file_prefix)),
       file_extension(std::move(_file_extension)),
       maximum_file_size_in_kb(_maximum_file_size),
       storage_limit_in_kb(_storage_limit),
-      discard_2_week_logs(_discard_2_week_logs) {}
+      discard_old_logs(_discard_old_logs) {}
 
   /**
    * The path to the folder where all files are stored. Can be absolute or relative
@@ -69,7 +69,7 @@ struct FileManagerStrategyOptions {
   /**
    * Option for the user to discard logs older than 14 days
    */
-  bool discard_2_week_logs;
+  bool discard_old_logs;
 };
 
 static const FileManagerStrategyOptions kDefaultFileManagerStrategyOptions{"~/.ros/cwlogs", "cwlog", ".log", 1024, 1024*1024};

--- a/file_management/include/file_management/file_manager_options.h
+++ b/file_management/include/file_management/file_manager_options.h
@@ -35,12 +35,14 @@ struct FileManagerStrategyOptions {
     std::string _file_prefix,
     std::string _file_extension,
     size_t _maximum_file_size,
-    size_t _storage_limit)
+    size_t _storage_limit,
+    bool _discard_2_week_logs = false)
     : storage_directory(std::move(_storage_directory)),
       file_prefix(std::move(_file_prefix)),
       file_extension(std::move(_file_extension)),
       maximum_file_size_in_kb(_maximum_file_size),
-      storage_limit_in_kb(_storage_limit) {}
+      storage_limit_in_kb(_storage_limit),
+      discard_2_week_logs(_discard_2_week_logs) {}
 
   /**
    * The path to the folder where all files are stored. Can be absolute or relative
@@ -64,6 +66,10 @@ struct FileManagerStrategyOptions {
    * After this limit is reached files will start to be deleted, oldest first.
    */
   size_t storage_limit_in_kb{};
+  /**
+   * Option for the user to discard logs older than 14 days
+   */
+  bool discard_2_week_logs;
 };
 
 static const FileManagerStrategyOptions kDefaultFileManagerStrategyOptions{"~/.ros/cwlogs", "cwlog", ".log", 1024, 1024*1024};

--- a/file_management/include/file_management/file_manager_options.h
+++ b/file_management/include/file_management/file_manager_options.h
@@ -36,13 +36,13 @@ struct FileManagerStrategyOptions {
     std::string _file_extension,
     size_t _maximum_file_size,
     size_t _storage_limit,
-    bool _discard_old_logs = false)
+    bool _delete_stale_data = false)
     : storage_directory(std::move(_storage_directory)),
       file_prefix(std::move(_file_prefix)),
       file_extension(std::move(_file_extension)),
       maximum_file_size_in_kb(_maximum_file_size),
       storage_limit_in_kb(_storage_limit),
-      discard_old_logs(_discard_old_logs) {}
+      delete_stale_data(_delete_stale_data) {}
 
   /**
    * The path to the folder where all files are stored. Can be absolute or relative
@@ -69,10 +69,10 @@ struct FileManagerStrategyOptions {
   /**
    * Option for the user to discard logs older than 14 days
    */
-  bool discard_old_logs;
+  bool delete_stale_data;
 };
 
-static const FileManagerStrategyOptions kDefaultFileManagerStrategyOptions{"~/.ros/cwlogs", "cwlog", ".log", 1024, 1024*1024};
+static const FileManagerStrategyOptions kDefaultFileManagerStrategyOptions{"~/.ros/cwlogs", "cwlog", ".log", 1024, 1024*1024, false};
 
 }  // namespace FileManagement
 }  // namespace Aws

--- a/file_management/include/file_management/file_manager_options.h
+++ b/file_management/include/file_management/file_manager_options.h
@@ -67,7 +67,7 @@ struct FileManagerStrategyOptions {
    */
   size_t storage_limit_in_kb{};
   /**
-   * Option for the user to discard logs older than 14 days
+   * Option for the user to delete logs older than 14 days
    */
   bool delete_stale_data;
 };

--- a/file_management/include/file_management/file_upload/file_manager.h
+++ b/file_management/include/file_management/file_upload/file_manager.h
@@ -69,6 +69,10 @@ public:
     const FileObject<T> &log_messages) = 0;
 
   virtual void setStatusMonitor(std::shared_ptr<StatusMonitor> status_monitor) = 0;
+
+  virtual void discardFiles(){
+    
+  };
 };
 
 /**

--- a/file_management/include/file_management/file_upload/file_manager.h
+++ b/file_management/include/file_management/file_upload/file_manager.h
@@ -218,13 +218,14 @@ public:
     rejects batches with log events older than 14 days.
   */
   void deleteStaleData(){
+    std::lock_guard<std::mutex> lock(active_delete_stale_data_mutex_);
+    
     if (stale_data_.empty()) {
       return;
     }
 
     AWS_LOG_INFO(__func__, "Deleting stale data from Logbatch");
 
-    std::lock_guard<std::mutex> lock(active_delete_stale_data_mutex_);
     std::list<FileManagement::DataToken> data_tokens;
     int logsDeleted = 0;
     while(!stale_data_.empty()){

--- a/file_management/include/file_management/file_upload/file_manager.h
+++ b/file_management/include/file_management/file_upload/file_manager.h
@@ -70,9 +70,7 @@ public:
 
   virtual void setStatusMonitor(std::shared_ptr<StatusMonitor> status_monitor) = 0;
 
-  virtual void discardFiles(){
-    
-  };
+  virtual void deleteStaleData() = 0;
 };
 
 /**
@@ -214,6 +212,34 @@ public:
     return false;
   }
 
+  /*
+    If the user cfg options for delete_stale_data and a log is over 14 days old from
+    the latest time,it will be deleted. This is because the AWS API for PutLogEvents
+    rejects batches with log events older than 14 days.
+  */
+  void deleteStaleData(){
+    if (stale_data_.empty()) {
+      return;
+    }
+
+    AWS_LOG_INFO(__func__, "Deleting stale data from Logbatch");
+
+    std::lock_guard<std::mutex> lock(active_delete_stale_data_mutex_);
+    std::list<FileManagement::DataToken> data_tokens;
+    int logsDeleted = 0;
+    while(!stale_data_.empty()){
+      file_manager_strategy_->resolve(stale_data_.back(), true);
+      logsDeleted++;
+      stale_data_.pop_back();
+    }
+
+    if(logsDeleted > 0){
+      AWS_LOG_INFO(__func__, "%d logs were deleted since the time"
+        " difference was > 14 days./n", logsDeleted
+        );
+    }
+  }
+
 protected:
   /**
    * The object that keeps track of which files to delete, read, or write to.
@@ -230,6 +256,18 @@ protected:
    * The status monitor for notifying an observer when files are available.
    */
   std::shared_ptr<StatusMonitor> file_status_monitor_;
+
+  /**
+   * A lock on the stale_data_ vector to prevent elements from being read or modified to
+   * stale_data_ while data is being read or modified from it.
+   */
+  std::mutex active_delete_stale_data_mutex_;
+
+  /**
+   * Store logs > 14 days old in this vector and resolve them in the delete_stale_data
+   * function after upload log task has been successfully enqueued.
+   */
+  std::vector<FileManagement::DataToken> stale_data_;
 
 };
 

--- a/file_management/include/file_management/file_upload/file_manager_strategy.h
+++ b/file_management/include/file_management/file_upload/file_manager_strategy.h
@@ -304,7 +304,7 @@ public:
   bool isDataAvailable() override;
 
   /**
-   * Returns true if user set the option to remove logs older than 14 days
+   * Returns true if user set the option to remove older logs
    */
   bool discardOldLogs() override;
 

--- a/file_management/include/file_management/file_upload/file_manager_strategy.h
+++ b/file_management/include/file_management/file_upload/file_manager_strategy.h
@@ -141,6 +141,8 @@ public:
 
   virtual bool isDataAvailable() = 0;
 
+  virtual bool discardOldLogs() = 0;
+
   virtual DataToken read(std::string &data) = 0;
 
   virtual void write(const std::string &data) = 0;
@@ -300,6 +302,11 @@ public:
    * @return bool if there is data available
    */
   bool isDataAvailable() override;
+
+  /**
+   * Returns true if user set the option to remove logs older than 14 days
+   */
+  bool discardOldLogs() override;
 
   /**
    * Reads a line of data from file storage. The most recent data in storage is read first. 

--- a/file_management/include/file_management/file_upload/file_manager_strategy.h
+++ b/file_management/include/file_management/file_upload/file_manager_strategy.h
@@ -141,7 +141,9 @@ public:
 
   virtual bool isDataAvailable() = 0;
 
-  virtual bool discardOldLogs() = 0;
+  virtual bool isDeleteStaleData() = 0;
+
+  virtual void setDeleteStaleData(bool set_stale_data) = 0;
 
   virtual DataToken read(std::string &data) = 0;
 
@@ -304,9 +306,16 @@ public:
   bool isDataAvailable() override;
 
   /**
-   * Returns true if user set the option to remove older logs
+   * Deletes stale data that won't be accepted by the CloudWatch API. 
+   * This is done in a separate method so it doesn't block the current publishing task after
+   * reading the data.
    */
-  bool discardOldLogs() override;
+  bool isDeleteStaleData() override;
+
+  /**
+   * Sets option for deleting stale data that won't be accepted by the CloudWatch API.
+   */
+  void setDeleteStaleData(bool set_stale_data) override;
 
   /**
    * Reads a line of data from file storage. The most recent data in storage is read first. 

--- a/file_management/include/file_management/file_upload/file_manager_strategy.h
+++ b/file_management/include/file_management/file_upload/file_manager_strategy.h
@@ -143,8 +143,6 @@ public:
 
   virtual bool isDeleteStaleData() = 0;
 
-  virtual void setDeleteStaleData(bool set_stale_data) = 0;
-
   virtual DataToken read(std::string &data) = 0;
 
   virtual void write(const std::string &data) = 0;
@@ -311,11 +309,6 @@ public:
    * reading the data.
    */
   bool isDeleteStaleData() override;
-
-  /**
-   * Sets option for deleting stale data that won't be accepted by the CloudWatch API.
-   */
-  void setDeleteStaleData(bool set_stale_data) override;
 
   /**
    * Reads a line of data from file storage. The most recent data in storage is read first. 

--- a/file_management/include/file_management/file_upload/file_upload_streamer.h
+++ b/file_management/include/file_management/file_upload/file_upload_streamer.h
@@ -146,7 +146,8 @@ protected:
      * 1. First wait for work on all the status conditions. (i.e wait until files are available to upload)
      * 2. Read a batch of data from the file_manager
      * 3. Queue up the task to be worked on.
-     * 4. Wait for the task to be completed to continue.
+     * 4. Discard older logs if user option is enabled.
+     * 5. Wait for the upload task to be completed to continue.
      */
     inline void work() override {
       if (!stored_task_) {
@@ -195,6 +196,7 @@ protected:
         AWS_LOG_DEBUG(__func__,
                      "Enqueue failed");
       }
+      data_reader_->discardFiles();
     }
 
 private:

--- a/file_management/include/file_management/file_upload/file_upload_streamer.h
+++ b/file_management/include/file_management/file_upload/file_upload_streamer.h
@@ -146,7 +146,7 @@ protected:
      * 1. First wait for work on all the status conditions. (i.e wait until files are available to upload)
      * 2. Read a batch of data from the file_manager
      * 3. Queue up the task to be worked on.
-     * 4. Discard older logs if user option is enabled.
+     * 4. Delete older logs if user option is enabled.
      * 5. Wait for the upload task to be completed to continue.
      */
     inline void work() override {
@@ -196,7 +196,7 @@ protected:
         AWS_LOG_DEBUG(__func__,
                      "Enqueue failed");
       }
-      data_reader_->discardFiles();
+      data_reader_->deleteStaleData();
     }
 
 private:

--- a/file_management/src/file_upload/file_manager_strategy.cpp
+++ b/file_management/src/file_upload/file_manager_strategy.cpp
@@ -277,10 +277,6 @@ bool FileManagerStrategy::isDeleteStaleData() {
   return options_.delete_stale_data;
 }
 
-void FileManagerStrategy::setDeleteStaleData(bool set_stale_data) {
-  options_.delete_stale_data = set_stale_data;
-}
-
 void FileManagerStrategy::write(const std::string &data) {
   try {
     checkIfWriteFileShouldRotate(data.size());

--- a/file_management/src/file_upload/file_manager_strategy.cpp
+++ b/file_management/src/file_upload/file_manager_strategy.cpp
@@ -273,6 +273,10 @@ bool FileManagerStrategy::isDataAvailable() {
   return !active_read_file_.empty() || !stored_files_.empty() || active_write_file_size_ > 0;
 }
 
+bool FileManagerStrategy::discardOldLogs() {
+  return options_.discard_2_week_logs;
+}
+
 void FileManagerStrategy::write(const std::string &data) {
   try {
     checkIfWriteFileShouldRotate(data.size());

--- a/file_management/src/file_upload/file_manager_strategy.cpp
+++ b/file_management/src/file_upload/file_manager_strategy.cpp
@@ -273,8 +273,12 @@ bool FileManagerStrategy::isDataAvailable() {
   return !active_read_file_.empty() || !stored_files_.empty() || active_write_file_size_ > 0;
 }
 
-bool FileManagerStrategy::discardOldLogs() {
-  return options_.discard_old_logs;
+bool FileManagerStrategy::isDeleteStaleData() {
+  return options_.delete_stale_data;
+}
+
+void FileManagerStrategy::setDeleteStaleData(bool set_stale_data) {
+  options_.delete_stale_data = set_stale_data;
 }
 
 void FileManagerStrategy::write(const std::string &data) {

--- a/file_management/src/file_upload/file_manager_strategy.cpp
+++ b/file_management/src/file_upload/file_manager_strategy.cpp
@@ -274,7 +274,7 @@ bool FileManagerStrategy::isDataAvailable() {
 }
 
 bool FileManagerStrategy::discardOldLogs() {
-  return options_.discard_2_week_logs;
+  return options_.discard_old_logs;
 }
 
 void FileManagerStrategy::write(const std::string &data) {

--- a/file_management/test/file_management/file_upload_streamer_test.cpp
+++ b/file_management/test/file_management/file_upload_streamer_test.cpp
@@ -39,6 +39,10 @@ public:
     void(std::shared_ptr<StatusMonitor> monitor));
   MOCK_METHOD0(isDataAvailableToRead, bool());
 
+  void deleteStaleData() override {
+    return;
+  }
+
   /**
    * Set the observer for the queue.
    *


### PR DESCRIPTION
Closes #54 
[AWS PutLogEvents](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html) will not upload a batch log if the logs in the batch are older than 14 days. Therefore we will allow the user to specify an option in FileManagerStrategy to automatically delete 14 day old logs from the batch.

In an effort to minimize runtime, we will first upload the correctly batched logs before deleting any remaining logs over 14 days old.

Related PR opened in cloudwatchlogs-ros1 to allow user to set delete_stale_data option in FileManagerStrategyOptions:
[Add option for FileManagerStrategy delete stale data #64](https://github.com/aws-robotics/cloudwatchlogs-ros1/pull/64)

Signed-off-by: Jesse Ikawa <jikawa@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
