### PR TITLE
Add AWS logging to batch tests

### DIFF
--- a/cloudwatch_logs_common/src/utils/log_file_manager.cpp
+++ b/cloudwatch_logs_common/src/utils/log_file_manager.cpp
@@ -76,8 +76,8 @@ FileObject<LogCollection> LogFileManager::readBatch(
   }
 
   if(batch_size != log_data.size()){
-    AWS_LOG_INFO(__func__, "%d logs were not batched since the time"
-      " difference was > 24 hours. Will try again in a separate batch./n"
+    AWS_LOG_WARN(__func__, "%d logs were not batched since the time"
+      " difference was > 24 hours. Will try again in a separate batch."
       , batch_size - log_data.size()
       );
   }

--- a/cloudwatch_logs_common/test/log_batch_test.cpp
+++ b/cloudwatch_logs_common/test/log_batch_test.cpp
@@ -13,8 +13,11 @@
  * permissions and limitations under the License.
  */
 
-#include <gtest/gtest.h>
+#include <aws/core/utils/logging/AWSLogging.h>
+#include <aws/core/utils/logging/ConsoleLogSystem.h>
 #include <cloudwatch_logs_common/utils/log_file_manager.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
 
 using Aws::CloudWatchLogs::Utils::LogFileManager;
 using namespace Aws::CloudWatchLogs;
@@ -251,7 +254,12 @@ TEST(DeleteOptionTest, file_manager_delete_false) {
 
 int main(int argc, char** argv)
 {
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+  Aws::Utils::Logging::InitializeAWSLogging(
+      Aws::MakeShared<Aws::Utils::Logging::ConsoleLogSystem>(
+          "RunUnitTests", Aws::Utils::Logging::LogLevel::Trace));
+  ::testing::InitGoogleMock(&argc, argv);
+  int exitCode = RUN_ALL_TESTS();
+  Aws::Utils::Logging::ShutdownAWSLogging();
+  return exitCode;
 }
 

--- a/file_management/include/file_management/file_upload/file_manager.h
+++ b/file_management/include/file_management/file_upload/file_manager.h
@@ -236,7 +236,7 @@ public:
 
     if(logsDeleted > 0){
       AWS_LOG_INFO(__func__, "%d logs were deleted since the time"
-        " difference was > 14 days./n", logsDeleted
+        " difference was > 14 days.", logsDeleted
         );
     }
   }


### PR DESCRIPTION
Add AWS logging to the log batch unit tests so that the log files can verify the performance of readBatch and deleteStaleData functions.

Signed-off-by: Jesse Ikawa <jikawa@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
