### PR TITLE
Limit the rate of cloudwatch log uploading to match API service limits

### DIFF
--- a/cloudwatch_logs_common/include/cloudwatch_logs_common/utils/cloudwatch_logs_facade.h
+++ b/cloudwatch_logs_common/include/cloudwatch_logs_common/utils/cloudwatch_logs_facade.h
@@ -59,6 +59,10 @@ public:
   /**
    *  @brief Sends a list of logs to CloudWatch
    *
+   *  This operation may block for a bounded amount of time to rate limit calls to the
+   *  CloudWatch Logs API. It is expected that tasks dispatched to this facade occur on worker
+   *  threads so that main loop program processing is not affected by this delay.
+   *
    *  @param next_token The next sequence token to use for sending logs to cloudwatch
    *  @param log_group A reference to a string with the log group name for all the logs being posted
    *  @param log_stream A reference to a string with the log stream name for all the logs being
@@ -132,6 +136,9 @@ protected:
 private:
   Aws::CloudWatchLogs::ROSCloudWatchLogsErrors SendLogsRequest(
     const Aws::CloudWatchLogs::Model::PutLogEventsRequest & request, Aws::String & next_token);
+
+  // The last time PutLogEvents was called, used to track rate limiting
+  std::chrono::milliseconds last_put_time_{0};
 
 };
 

--- a/cloudwatch_logs_common/src/utils/cloudwatch_logs_facade.cpp
+++ b/cloudwatch_logs_common/src/utils/cloudwatch_logs_facade.cpp
@@ -30,12 +30,24 @@
 #include <cloudwatch_logs_common/utils/cloudwatch_logs_facade.h>
 #include <cloudwatch_logs_common/definitions/definitions.h>
 
+namespace {
+// Return the current monotonic time in milliseconds since the epoch
+std::chrono::milliseconds now() {
+  return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch());
+}
+}  // unnamed namespace
 
 namespace Aws {
 namespace CloudWatchLogs {
 namespace Utils {
 
 constexpr uint16_t kMaxLogsPerRequest = 100;
+
+/**
+ * See https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/cloudwatch_limits_cwl.html
+ * PutLogEvents is limited to 5 requests per second per stream (equivalent to 200ms period).
+ */
+const std::chrono::milliseconds kMinPutLogsPeriod{200};
 
 CloudWatchLogsFacade::CloudWatchLogsFacade(const Aws::Client::ClientConfiguration & client_config)
 {
@@ -51,7 +63,18 @@ Aws::CloudWatchLogs::ROSCloudWatchLogsErrors CloudWatchLogsFacade::SendLogsReque
   const Aws::CloudWatchLogs::Model::PutLogEventsRequest & request, Aws::String & next_token)
 {
   Aws::CloudWatchLogs::ROSCloudWatchLogsErrors status = CW_LOGS_SUCCEEDED;
+
+  // Rate limiting
+  const auto time_since_last_put = now() - last_put_time_;
+  if (time_since_last_put < kMinPutLogsPeriod) {
+    // This will wait _at most_ kMinPutLogsPeriod.
+    const auto sleep_for = kMinPutLogsPeriod - time_since_last_put;
+    AWS_LOG_WARN(__func__, "PutLogEvents occurring too quickly, rate limiting in effect. Delaying PutLogs call by %d ms", sleep_for.count());
+    std::this_thread::sleep_for(kMinPutLogsPeriod - time_since_last_put);
+  }
+
   auto response = this->cw_client_->PutLogEvents(request);
+  last_put_time_ = now();
   if (!response.IsSuccess()) {
 
     AWS_LOGSTREAM_ERROR(__func__, "Send log request failed due to: "

--- a/cloudwatch_logs_common/src/utils/cloudwatch_logs_facade.cpp
+++ b/cloudwatch_logs_common/src/utils/cloudwatch_logs_facade.cpp
@@ -70,7 +70,7 @@ Aws::CloudWatchLogs::ROSCloudWatchLogsErrors CloudWatchLogsFacade::SendLogsReque
     // This will wait _at most_ kMinPutLogsPeriod.
     const auto sleep_for = kMinPutLogsPeriod - time_since_last_put;
     AWS_LOG_WARN(__func__, "PutLogEvents occurring too quickly, rate limiting in effect. Delaying PutLogs call by %d ms", sleep_for.count());
-    std::this_thread::sleep_for(kMinPutLogsPeriod - time_since_last_put);
+    std::this_thread::sleep_for(sleep_for);
   }
 
   auto response = this->cw_client_->PutLogEvents(request);

--- a/cloudwatch_logs_common/test/cloudwatch_facade_test.cpp
+++ b/cloudwatch_logs_common/test/cloudwatch_facade_test.cpp
@@ -267,8 +267,12 @@ TEST_F(TestCloudWatchFacade, TestCWLogsFacade_CreateLogStream_SuccessResponse)
 
 TEST_F(TestCloudWatchFacade, TestCWLogsFacade_CreateLogStream_FailedResponse)
 {
-    auto* failedOutcome =
-        new Aws::CloudWatchLogs::Model::CreateLogStreamOutcome();
+    // Choosing an arbitrary unhandled error code to initialize, for deterministic behavior
+    // When left uninitialized, on some systems it may come out as RESOURCE_ALREADY_EXISTS
+    Aws::Client::AWSError<Aws::CloudWatchLogs::CloudWatchLogsErrors> error(
+        Aws::CloudWatchLogs::CloudWatchLogsErrors::INTERNAL_FAILURE, false);
+
+    auto* failedOutcome = new Aws::CloudWatchLogs::Model::CreateLogStreamOutcome(error);
 
     EXPECT_CALL(*mock_client_p, CreateLogStream(testing::_))
         .WillOnce(testing::Return(*failedOutcome));


### PR DESCRIPTION
Resolves https://github.com/aws-robotics/cloudwatchlogs-ros1/issues/63

By making the max rate configurable at which the service will dispatch upload tasks, we can avoid ever hitting a throttling exception from the AWS APIs.

My test situation was to use the following test script in conjunction with `roslaunch cloudwatch_logger sample_application.launch --screen`

```
import rospy
import time

rospy.init_node('arstarst')

count = 0
while not rospy.is_shutdown():
    count += 1
    rospy.loginfo("test {}".format(count))
    time.sleep(0.001)
```

This script output logs faster than they could be uploaded, so it reliably caused a throttling error. This is also true when there were offline logs written to disk that were uploaded on reconnecting - this change hits both the live and offline cases because it is the central point through which tasks go.

CloudWatch Metrics will not be throttled, because the minimum period defaults to 0.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
