### PR TITLE
Test PR for general pattern to upgrade to latest CI actions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -37,16 +37,14 @@ jobs:
       ROS_DISTRO: ${{ matrix.ros_distro }}
       ROS_VERSION: ${{ matrix.ros_version }}
     steps:
-    # TODO(setup-ros-docker#7): calling chown is necessary for now
-    - name: Run setup-ros-docker workaround
-      run: sudo chown -R rosbuild:rosbuild "$HOME" .
     # Needed to access the vcs repos file from the workspace
     - name: Checkout source
       uses: actions/checkout@v2
     - name: Run action-ros-ci to build and test
-      uses: ros-tooling/action-ros-ci@0.0.17
+      uses: ros-tooling/action-ros-ci@0.1.0
       with:
-        source-ros-binary-installation: ${{ matrix.ros_distro }}
+        target-ros1-distro: ${{ matrix.ros_version == '1' && matrix.ros_distro || '' }}
+        target-ros2-distro: ${{ matrix.ros_version == '2' && matrix.ros_distro || '' }}
         package-name: cloudwatch_logs_common dataflow_lite cloudwatch_metrics_common file_management
         extra-cmake-args: ${{ matrix.extra_cmake_args }}
         vcs-repo-file-url: ''

--- a/.github/workflows/build_and_test_release_latest.yml
+++ b/.github/workflows/build_and_test_release_latest.yml
@@ -33,16 +33,14 @@ jobs:
       ROS_DISTRO: ${{ matrix.ros_distro }}
       ROS_VERSION: ${{ matrix.ros_version }}
     steps:
-    # TODO(setup-ros-docker#7): calling chown is necessary for now
-    - name: Run setup-ros-docker workaround
-      run: sudo chown -R rosbuild:rosbuild "$HOME" .
     # Needed to access the vcs repos file from the workspace
     - name: Checkout source
       uses: actions/checkout@v2
     - name: Run action-ros-ci to build and test
-      uses: ros-tooling/action-ros-ci@0.0.17
+      uses: ros-tooling/action-ros-ci@0.1.0
       with:
-        source-ros-binary-installation: ${{ matrix.ros_distro }}
+        target-ros1-distro: ${{ matrix.ros_version == '1' && matrix.ros_distro || '' }}
+        target-ros2-distro: ${{ matrix.ros_version == '2' && matrix.ros_distro || '' }}
         package-name: cloudwatch_logs_common dataflow_lite cloudwatch_metrics_common file_management
         extra-cmake-args: ${{ matrix.extra_cmake_args }}
         # schedule runs against the default branch (master), so specify release-latest via repos file


### PR DESCRIPTION
Upgrade to action-ros-ci 0.1.0, remove outdated workaround for setup-ros-docker containers



*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.